### PR TITLE
feat: refactor lookup logic

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -259,44 +259,6 @@ func (s *State) LookupRecords(recordTypes []string, recordName string) ([]Domain
 	return ret, nil
 }
 
-// LookupNameserverRecord searches the domain nameserver entries for one matching the requested record
-func (s *State) LookupNameserverRecord(
-	recordName string,
-) (map[string]string, error) {
-	ret := map[string]string{}
-	err := s.db.View(func(txn *badger.Txn) error {
-		opts := badger.DefaultIteratorOptions
-		// Makes key scans faster
-		opts.PrefetchValues = false
-		it := txn.NewIterator(opts)
-		defer it.Close()
-		for it.Rewind(); it.Valid(); it.Next() {
-			item := it.Item()
-			k := item.Key()
-			if strings.HasSuffix(
-				string(k),
-				fmt.Sprintf("_nameserver_%s", recordName),
-			) {
-				err := item.Value(func(v []byte) error {
-					ret[recordName] = string(v)
-					return nil
-				})
-				if err != nil {
-					return err
-				}
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(ret) == 0 {
-		return nil, nil
-	}
-	return ret, nil
-}
-
 func GetState() *State {
 	return globalState
 }


### PR DESCRIPTION
This commit does the following:

* support lookup of more than NS from local storage
* add convenience function for converting from our storage format to dns.RR
* remove NS lookup logic for fallback servers and pass along query verbatim if not in local storage
* remove (now) unneeded state helper function

Fixes #107 and #159