### PR TITLE
fix(lint): avoid string concat in loop

### DIFF
--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -552,47 +552,53 @@ func randomFallbackServer() string {
 }
 
 func formatMessageAnswerSection(section []dns.RR) string {
-	ret := "[ "
+	var sb strings.Builder
+	sb.WriteByte('[')
+	sb.WriteByte(' ')
 	for idx, rr := range section {
-		ret += fmt.Sprintf(
-			"< %s >",
-			strings.ReplaceAll(
-				strings.TrimPrefix(
-					rr.String(),
-					";",
-				),
-				"\t",
-				" ",
+		sb.WriteByte('<')
+		sb.WriteByte(' ')
+		sb.WriteString(strings.ReplaceAll(
+			strings.TrimPrefix(
+				rr.String(),
+				";",
 			),
-		)
+			"\t",
+			" ",
+		))
+		sb.WriteByte('>')
+		sb.WriteByte(' ')
 		if idx != len(section)-1 {
-			ret += `,`
+			sb.WriteByte(',')
 		}
-		ret += ` `
+		sb.WriteByte(' ')
 	}
-	ret += "]"
-	return ret
+	sb.WriteByte(']')
+	return sb.String()
 }
 
 func formatMessageQuestionSection(section []dns.Question) string {
-	ret := "[ "
+	var sb strings.Builder
+	sb.WriteByte('[')
+	sb.WriteByte(' ')
 	for idx, question := range section {
-		ret += fmt.Sprintf(
-			"< %s >",
-			strings.ReplaceAll(
-				strings.TrimPrefix(
-					question.String(),
-					";",
-				),
-				"\t",
-				" ",
+		sb.WriteByte('<')
+		sb.WriteByte(' ')
+		sb.WriteString(strings.ReplaceAll(
+			strings.TrimPrefix(
+				question.String(),
+				";",
 			),
-		)
+			"\t",
+			" ",
+		))
+		sb.WriteByte('>')
+		sb.WriteByte(' ')
 		if idx != len(section)-1 {
-			ret += `,`
+			sb.WriteByte(',')
 		}
-		ret += ` `
+		sb.WriteByte(' ')
 	}
-	ret += "]"
-	return ret
+	sb.WriteByte(']')
+	return sb.String()
 }

--- a/internal/handshake/domain.go
+++ b/internal/handshake/domain.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 )
 
 const (
@@ -282,8 +283,8 @@ func domainRecordIPv6Decode(r *BytesReader) (net.IP, error) {
 }
 
 func domainRecordNameDecode(r *BytesReader) (string, error) {
+	var sb strings.Builder
 	// NOTE: this function is mostly ported straight from hnsd
-	var name string
 	for {
 		c, err := r.ReadByte()
 		if err != nil {
@@ -311,10 +312,10 @@ func domainRecordNameDecode(r *BytesReader) (string, error) {
 				if b == 0x2e {
 					b = 0xfe
 				}
-				name += string([]byte{b})
+				sb.WriteByte(b)
 			}
-			if len(name) > 0 {
-				name += "."
+			if sb.Len() > 0 {
+				sb.WriteByte('.')
 			}
 		case 0xc0:
 			// Lookup name from earlier in the buffer
@@ -338,5 +339,5 @@ func domainRecordNameDecode(r *BytesReader) (string, error) {
 			return "", errors.New("unexpected value")
 		}
 	}
-	return name, nil
+	return sb.String(), nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal performance and string-construction improvements to DNS and handshake handling. 
  * Reformulated internal formatting and name-decoding logic for more efficient string assembly.
  * No user-facing behavior changes, no modifications to public APIs, and no changes required from users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->