### PR TITLE
feat: Handshake ping/pong message support

### DIFF
--- a/internal/handshake/protocol/messages.go
+++ b/internal/handshake/protocol/messages.go
@@ -77,6 +77,10 @@ func decodeMessage(header *msgHeader, payload []byte) (Message, error) {
 		ret = &MsgVersion{}
 	case MessageVerack:
 		ret = &MsgVerack{}
+	case MessagePing:
+		ret = &MsgPing{}
+	case MessagePong:
+		ret = &MsgPong{}
 	case MessageGetAddr:
 		ret = &MsgGetAddr{}
 	case MessageAddr:
@@ -300,9 +304,41 @@ func (*MsgVerack) Decode(data []byte) error {
 	return nil
 }
 
-type MsgPing struct{}
+type MsgPing struct {
+	Nonce uint64
+}
 
-type MsgPong struct{}
+func (m *MsgPing) Encode() []byte {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, binary.LittleEndian, m.Nonce)
+	return buf.Bytes()
+}
+
+func (m *MsgPing) Decode(data []byte) error {
+	if len(data) != 8 {
+		return errors.New("invalid payload length")
+	}
+	m.Nonce = binary.LittleEndian.Uint64(data)
+	return nil
+}
+
+type MsgPong struct {
+	Nonce uint64
+}
+
+func (m *MsgPong) Encode() []byte {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, binary.LittleEndian, m.Nonce)
+	return buf.Bytes()
+}
+
+func (m *MsgPong) Decode(data []byte) error {
+	if len(data) != 8 {
+		return errors.New("invalid payload length")
+	}
+	m.Nonce = binary.LittleEndian.Uint64(data)
+	return nil
+}
 
 type MsgGetAddr struct{}
 

--- a/internal/handshake/protocol/peer.go
+++ b/internal/handshake/protocol/peer.go
@@ -194,7 +194,7 @@ func (p *Peer) recvLoop() {
 }
 
 func (p *Peer) handleMessage(msg Message) error {
-	switch msg.(type) {
+	switch m := msg.(type) {
 	case *MsgVersion, *MsgVerack:
 		p.handshakeCh <- msg
 	case *MsgAddr:
@@ -205,8 +205,21 @@ func (p *Peer) handleMessage(msg Message) error {
 		p.blockCh <- msg
 	case *MsgProof:
 		p.proofCh <- msg
+	case *MsgPing:
+		return p.handlePing(m)
 	default:
 		return fmt.Errorf("unknown message type: %T", msg)
+	}
+	return nil
+}
+
+// handlePing responds to Ping messages with a Pong message containing the same nonce value
+func (p *Peer) handlePing(msg *MsgPing) error {
+	pongMsg := &MsgPong{
+		Nonce: msg.Nonce,
+	}
+	if err := p.sendMessage(MessagePong, pongMsg); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #435

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Ping/Pong support to the handshake protocol. Peers now handle Ping and reply with a matching-nonce Pong.

- **New Features**
  - Implemented MsgPing and MsgPong with a 64-bit nonce and encode/decode logic.
  - Registered Ping/Pong in message decoding so they’re recognized on receive.
  - Added peer-side Ping handling that sends a Pong with the same nonce.

<sup>Written for commit cbb2c301548b3a78f351c966bebb660db4eb8ada. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ping and Pong messages to enable connection health monitoring and keep-alive functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->