### PR TITLE
fix: use correct read uvarint function when decoding Handshake covenants

### DIFF
--- a/internal/handshake/covenant.go
+++ b/internal/handshake/covenant.go
@@ -43,12 +43,12 @@ func (c *GenericCovenant) Decode(r io.Reader) error {
 	if err := binary.Read(r, binary.LittleEndian, &c.Type); err != nil {
 		return err
 	}
-	itemCount, err := binary.ReadUvarint(r.(io.ByteReader))
+	itemCount, err := ReadUvarintReader(r)
 	if err != nil {
 		return err
 	}
 	for range itemCount {
-		itemLength, err := binary.ReadUvarint(r.(io.ByteReader))
+		itemLength, err := ReadUvarintReader(r)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed Handshake covenant decoding by using ReadUvarintReader for varints instead of binary.ReadUvarint with a ByteReader cast. Prevents panics on non-ByteReader inputs and correctly parses item counts and lengths.

<sup>Written for commit 53830a8fa42481579919ea1569518ec40db17fb9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to code reliability and maintainability. No user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->