### PR TITLE
refactor: merge Handshake protocol sub-package into main package

### DIFF
--- a/internal/handshake/messages_test.go
+++ b/internal/handshake/messages_test.go
@@ -4,15 +4,13 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-package protocol
+package handshake
 
 import (
 	"encoding/hex"
 	"net"
 	"reflect"
 	"testing"
-
-	"github.com/blinklabs-io/cdnsd/internal/handshake"
 )
 
 func TestMsgVersionEncodeDecode(t *testing.T) {
@@ -167,8 +165,8 @@ func TestMsgHeadersEncodeDecode(t *testing.T) {
 		{
 			binaryHex: "0232bb5134a541385e000000005b6ef2d3c1f3cdcadfd9a030ba1811efdd17740f14e166489760741d075992e00000000000000000000000000000000000000000000000000000000000000000000000150000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000059919422c20530ece2b328adf63ec3f35a10e79375731687a81dfa7cd83a24e728b17095216d5e211ba1f61031416a51efca54eacb8c9059440c4671b0625bbe00000000ffff001c0000000000000000000000000000000000000000000000000000000000000000032a8839c741385e000000000000000000a5e40e8ba291bd7e8649747fa7fb8a7af39f5bacdb7433cd2f59710000000000000000000000000000000000000000000000000000000000000000000000060000000c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000038180556e54cd70fd131130e154be4569945a6526d45add9ade6dbdfa34f54e25d1d56a37915cd1337b007806116ff623d973bec006280154472a6677eacbe0700000000ffff001c0000000000000000000000000000000000000000000000000000000000000000",
 			message: &MsgHeaders{
-				Headers: []*handshake.BlockHeader{
-					&handshake.BlockHeader{
+				Headers: []*BlockHeader{
+					&BlockHeader{
 						Nonce:        0x3451bb32,
 						Time:         0x5e3841a5,
 						PrevBlock:    [32]uint8{0x5b, 0x6e, 0xf2, 0xd3, 0xc1, 0xf3, 0xcd, 0xca, 0xdf, 0xd9, 0xa0, 0x30, 0xba, 0x18, 0x11, 0xef, 0xdd, 0x17, 0x74, 0xf, 0x14, 0xe1, 0x66, 0x48, 0x97, 0x60, 0x74, 0x1d, 0x7, 0x59, 0x92, 0xe0},
@@ -181,7 +179,7 @@ func TestMsgHeadersEncodeDecode(t *testing.T) {
 						Bits:         0x1c00ffff,
 						Mask:         [32]uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 					},
-					&handshake.BlockHeader{
+					&BlockHeader{
 						Nonce:        0x39882a03,
 						Time:         0x5e3841c7,
 						PrevBlock:    [32]uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0xa5, 0xe4, 0xe, 0x8b, 0xa2, 0x91, 0xbd, 0x7e, 0x86, 0x49, 0x74, 0x7f, 0xa7, 0xfb, 0x8a, 0x7a, 0xf3, 0x9f, 0x5b, 0xac, 0xdb, 0x74, 0x33, 0xcd, 0x2f, 0x59, 0x71},

--- a/internal/handshake/network.go
+++ b/internal/handshake/network.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-package protocol
+package handshake
 
 type Network struct {
 	Name        string

--- a/internal/handshake/peer.go
+++ b/internal/handshake/peer.go
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-package protocol
+package handshake
 
 import (
 	"crypto/rand"
@@ -16,8 +16,6 @@ import (
 	"net"
 	"sync"
 	"time"
-
-	"github.com/blinklabs-io/cdnsd/internal/handshake"
 )
 
 const (
@@ -303,7 +301,7 @@ func (p *Peer) GetPeers() ([]NetAddress, error) {
 }
 
 // GetHeaders requests a list of headers from the network peer
-func (p *Peer) GetHeaders(locator [][32]byte, stopHash [32]byte) ([]*handshake.BlockHeader, error) {
+func (p *Peer) GetHeaders(locator [][32]byte, stopHash [32]byte) ([]*BlockHeader, error) {
 	getHeadersMsg := &MsgGetHeaders{
 		Locator:  locator,
 		StopHash: stopHash,
@@ -327,7 +325,7 @@ func (p *Peer) GetHeaders(locator [][32]byte, stopHash [32]byte) ([]*handshake.B
 }
 
 // GetProof requests a proof for a domain name from the network peer
-func (p *Peer) GetProof(name string, rootHash [32]byte) (*handshake.Proof, error) {
+func (p *Peer) GetProof(name string, rootHash [32]byte) (*Proof, error) {
 	key := sha3.Sum256([]byte(name))
 	getProofMsg := &MsgGetProof{
 		Root: rootHash,
@@ -352,7 +350,7 @@ func (p *Peer) GetProof(name string, rootHash [32]byte) (*handshake.Proof, error
 }
 
 // GetBlock requests the specified block from the network peer
-func (p *Peer) GetBlock(hash [32]byte) (*handshake.Block, error) {
+func (p *Peer) GetBlock(hash [32]byte) (*Block, error) {
 	getDataMsg := &MsgGetData{
 		Inventory: []InvItem{
 			{
@@ -379,8 +377,8 @@ func (p *Peer) GetBlock(hash [32]byte) (*handshake.Block, error) {
 	}
 }
 
-// SyncFunc is a callback function that takes a *handshake.Block, optionally returning its own error
-type SyncFunc func(*handshake.Block) error
+// SyncFunc is a callback function that takes a *Block, optionally returning its own error
+type SyncFunc func(*Block) error
 
 // Sync starts an async process to sync the blockchain, starting with the specified locator
 // and calling the specified callback for each fetched block or sync-related error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Merged the Handshake protocol sub-package into the main handshake package to simplify structure and remove cross-package dependencies. This makes protocol types and helpers local, reduces imports, and clarifies ownership.

- **Refactors**
  - Moved protocol files into internal/handshake and changed package name from protocol to handshake.
  - Switched to local types and helpers (Block, BlockHeader, Proof, Read/WriteUvarint, NewBlock*).
  - Updated Peer APIs and SyncFunc to use local types; removed redundant internal imports.

- **Migration**
  - Update imports from internal/handshake/protocol to internal/handshake.

<sup>Written for commit 061e1f8cbe4eca6e2c4921c8f2df9085524bd953. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and structure to enhance maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->