### PR TITLE
feat: track Handshake domain resource updates

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -28,9 +28,11 @@ const (
 	discoveredAddrKey  = "discovered_addresses"
 	fingerprintKey     = "config_fingerprint"
 
-	recordKeyPrefix            = "r_"
-	domainKeyPrefix            = "d_"
+	cardanoRecordKeyPrefix     = "r_"
+	cardanoDomainKeyPrefix     = "d_"
 	handshakeNameHashKeyPrefix = "hs_name_hash_"
+	handshakeDomainKeyPrefix   = "hs_d_"
+	handshakeRecordKeyPrefix   = "hs_r_"
 )
 
 type State struct {
@@ -222,6 +224,20 @@ func (s *State) UpdateDomain(
 	domainName string,
 	records []DomainRecord,
 ) error {
+	return s.updateDomain(
+		domainName,
+		records,
+		cardanoDomainKeyPrefix,
+		cardanoRecordKeyPrefix,
+	)
+}
+
+func (s *State) updateDomain(
+	domainName string,
+	records []DomainRecord,
+	domainKeyPrefix string,
+	recordKeyPrefix string,
+) error {
 	err := s.db.Update(func(txn *badger.Txn) error {
 		// Add new records
 		recordKeys := make([]string, 0)
@@ -290,6 +306,18 @@ func (s *State) UpdateDomain(
 func (s *State) LookupRecords(
 	recordTypes []string,
 	recordName string,
+) ([]DomainRecord, error) {
+	return s.lookupRecords(
+		recordTypes,
+		recordName,
+		cardanoRecordKeyPrefix,
+	)
+}
+
+func (s *State) lookupRecords(
+	recordTypes []string,
+	recordName string,
+	recordKeyPrefix string,
 ) ([]DomainRecord, error) {
 	ret := []DomainRecord{}
 	recordName = strings.Trim(recordName, `.`)
@@ -365,6 +393,29 @@ func (s *State) GetHandshakeNameByHash(nameHash []byte) (string, error) {
 		return "", err
 	}
 	return ret, nil
+}
+
+func (s *State) UpdateHandshakeDomain(
+	domainName string,
+	records []DomainRecord,
+) error {
+	return s.updateDomain(
+		domainName,
+		records,
+		handshakeDomainKeyPrefix,
+		handshakeRecordKeyPrefix,
+	)
+}
+
+func (s *State) LookupHandshakeRecords(
+	recordTypes []string,
+	recordName string,
+) ([]DomainRecord, error) {
+	return s.lookupRecords(
+		recordTypes,
+		recordName,
+		handshakeRecordKeyPrefix,
+	)
 }
 
 func GetState() *State {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts Handshake domain resource data into DNS records and stores them during registration and updates. This enables lookups for Handshake domains and prepares serving DNS responses.

- **New Features**
  - Indexer parses Handshake resource data on register/update and writes records via UpdateHandshakeDomain.
  - Maps DS, NS, glue (A/AAAA), synth (A/AAAA with base32 name), and TXT into DomainRecord entries.
  - Adds state prefixes and APIs: UpdateHandshakeDomain and LookupHandshakeRecords.
  - Canonicalizes names with miekg/dns to ensure consistent storage.

<sup>Written for commit d0b9709a2156b7a3cfdfa197ea7483fe6bbc262e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Handshake domain integration: Handshake records (DS, NS, glue, Synth A/AAAA, TXT) are now converted and stored.
  * Improved domain record management: separate storage and dedicated lookup/update flows for Handshake and other domain types.
  * Records are now persisted and pruned to keep stored domain data current.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->