### PR TITLE
fix: don't try to decode empty resource data in covenants

### DIFF
--- a/handshake/covenant.go
+++ b/handshake/covenant.go
@@ -355,11 +355,13 @@ func NewRegisterCovenantFromGeneric(
 	// Decode height from bytes
 	ret.Height = binary.LittleEndian.Uint32(gc.Items[1])
 	// Decode resource data
-	tmpData, err := NewDomainResourceDataFromBytes(gc.Items[2])
-	if err != nil {
-		return nil, err
+	if len(gc.Items[2]) > 0 {
+		tmpData, err := NewDomainResourceDataFromBytes(gc.Items[2])
+		if err != nil {
+			return nil, err
+		}
+		ret.ResourceData = *tmpData
 	}
-	ret.ResourceData = *tmpData
 	return ret, nil
 }
 
@@ -391,11 +393,13 @@ func NewUpdateCovenantFromGeneric(
 	// Decode height from bytes
 	ret.Height = binary.LittleEndian.Uint32(gc.Items[1])
 	// Decode resource data
-	tmpData, err := NewDomainResourceDataFromBytes(gc.Items[2])
-	if err != nil {
-		return nil, err
+	if len(gc.Items[2]) > 0 {
+		tmpData, err := NewDomainResourceDataFromBytes(gc.Items[2])
+		if err != nil {
+			return nil, fmt.Errorf("decode domain resource data: %w", err)
+		}
+		ret.ResourceData = *tmpData
 	}
-	ret.ResourceData = *tmpData
 	return ret, nil
 }
 


### PR DESCRIPTION
Fixes #457



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents decoding empty resource data in Handshake register/update covenants to avoid errors when resource bytes are missing. Also adds clearer error messages when decoding domain resource data.

- **Bug Fixes**
  - Decode resource data only when bytes are present in gc.Items[2].
  - Add context to errors in NewUpdateCovenantFromGeneric.
  - Wrap version, record type, and record decode errors in DomainResourceData.decode with helpful context.
  - Stop processing on unknown record types instead of error to match hsd.

<sup>Written for commit 66e580504af236f77d98e45929648109f4e43e82. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of optional resource data so absent data no longer triggers decoding errors.
  * Stopped further decoding when encountering unsupported record types to avoid processing invalid records.

* **Chores**
  * Improved and standardized error messages with additional context to aid diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->