### PR TITLE
fix: stop processing resource data records on error

### DIFF
--- a/handshake/domain.go
+++ b/handshake/domain.go
@@ -107,11 +107,17 @@ recordLoop:
 		if record != nil {
 			err = record.decode(r)
 			if err != nil {
-				return fmt.Errorf("decode record: %w", err)
+				// Stop processing on record decode failure
+				// Don't return an error, because we want to return whatever records
+				// that we were able to process successfully
+				break recordLoop
 			}
 		}
 		d.Records = append(d.Records, record)
 	}
+	// golangci-lint doesn't like it that we break out of the loop on decode error but
+	// return a nil error here
+	// nolint:nilerr
 	return nil
 }
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop processing resource data records on decode error, breaking out of the loop so parsing ends gracefully without appending invalid records. Previously this returned an error; now we exit the loop to keep valid records and avoid hard failures.

<sup>Written for commit 5ee23e377dd85252bae43f4dea579383f5ad0888. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted handshake record processing so decoding errors stop further record processing instead of aborting; system continues without returning an error.
  * No changes to public interfaces or exported declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->