### PR TITLE
fix: correct formatting of generated SYNTH records

### DIFF
--- a/internal/indexer/handshake.go
+++ b/internal/indexer/handshake.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/blinklabs-io/cdnsd/handshake"
@@ -249,10 +250,13 @@ func handshakeResourceDataToDomainRecords(domainName string, resData handshake.D
 			if ip4 == nil {
 				return nil, fmt.Errorf("Synth4 record has invalid IPv4 address: %s", r.Address.String())
 			}
+			base32Enc := base32.HexEncoding.WithPadding(base32.NoPadding)
 			nsName := fmt.Sprintf(
 				"_%s._synth.",
-				base32.HexEncoding.EncodeToString(
-					ip4,
+				strings.ToLower(
+					base32Enc.EncodeToString(
+						ip4,
+					),
 				),
 			)
 			ret = append(
@@ -272,10 +276,13 @@ func handshakeResourceDataToDomainRecords(domainName string, resData handshake.D
 				},
 			)
 		case *handshake.Synth6DomainRecord:
+			base32Enc := base32.HexEncoding.WithPadding(base32.NoPadding)
 			nsName := fmt.Sprintf(
 				"_%s._synth.",
-				base32.HexEncoding.EncodeToString(
-					r.Address,
+				strings.ToLower(
+					base32Enc.EncodeToString(
+						r.Address,
+					),
 				),
 			)
 			ret = append(


### PR DESCRIPTION
Fixes #467





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correct the formatting of generated SYNTH4 and SYNTH6 record names so they use base32-hex without padding and are lowercase. This aligns with the Handshake spec and fixes lookup failures noted in #467.

<sup>Written for commit 591beb40467af67541f50cb009aedd52db972a60. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * NS names generated for synthesized IPv4/IPv6 domain records now use a lowercase, no‑padding base32-hex encoding, changing the canonical form of those names.
  * No changes to record synthesis logic or public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->