### PR TITLE
fix: exclude duplicate values in NS records

### DIFF
--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -444,9 +445,16 @@ func findNameserversForDomain(
 					return "", nil, err
 				}
 				for _, aRecord := range aRecords {
+					tmpIp := net.ParseIP(aRecord.Rhs)
+					// Skip duplicate IPs
+					if slices.ContainsFunc(ret[nsRecord.Rhs], func(x net.IP) bool {
+						return x.Equal(tmpIp)
+					}) {
+						continue
+					}
 					ret[nsRecord.Rhs] = append(
 						ret[nsRecord.Rhs],
-						net.ParseIP(aRecord.Rhs),
+						tmpIp,
 					)
 				}
 			}
@@ -468,9 +476,16 @@ func findNameserversForDomain(
 					return "", nil, err
 				}
 				for _, aRecord := range aRecords {
+					tmpIp := net.ParseIP(aRecord.Rhs)
+					// Skip duplicate IPs
+					if slices.ContainsFunc(ret[nsRecord.Rhs], func(x net.IP) bool {
+						return x.Equal(tmpIp)
+					}) {
+						continue
+					}
 					ret[nsRecord.Rhs] = append(
 						ret[nsRecord.Rhs],
-						net.ParseIP(aRecord.Rhs),
+						tmpIp,
 					)
 				}
 			}


### PR DESCRIPTION
Fixes #469

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop returning duplicate IPs for NS records by skipping repeated A record addresses during nameserver resolution. Each nameserver now has a unique IP list, fixing #469.

<sup>Written for commit d891470a17fa18c295a5db350917febfe70692e2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate IP addresses are now filtered out during nameserver lookups, improving lookup reliability and efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->