### PR TITLE
fix: exclude keys for non-matching domains on lookup

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -336,6 +336,12 @@ func (s *State) lookupRecords(
 			defer it.Close()
 			for it.Seek(keyPrefix); it.ValidForPrefix(keyPrefix); it.Next() {
 				item := it.Item()
+				// Skip keys that don't have a purely numeric suffix
+				// This means that they don't belong to the domain we are looking for
+				keySuffix := item.Key()[len(keyPrefix):]
+				if _, err := strconv.Atoi(string(keySuffix)); err != nil {
+					continue
+				}
 				val, err := item.ValueCopy(nil)
 				if err != nil {
 					return err


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes record lookup to return only entries for the requested domain by skipping keys with non-numeric suffixes. Prevents cross-domain collisions when different domains share the same prefix.

- **Bug Fixes**
  - In lookupRecords, ignore keys where the suffix after keyPrefix isn’t purely numeric (strconv.Atoi fails), ensuring we don’t include records from other domains.

<sup>Written for commit 69011ed21cdb6695c52ab1c47b88e8c293bf1d3a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved record lookup validation to ensure only properly formatted records are processed during retrieval operations, enhancing system stability and data integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->