### PR TITLE
refactor: remove fallback DNS server support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,13 +33,12 @@ type LoggingConfig struct {
 }
 
 type DnsConfig struct {
-	ListenAddress    string   `yaml:"address"          envconfig:"DNS_LISTEN_ADDRESS"`
-	ListenPort       uint     `yaml:"port"             envconfig:"DNS_LISTEN_PORT"`
-	ListenTlsPort    uint     `yaml:"tlsPort"          envconfig:"DNS_LISTEN_TLS_PORT"`
-	RecursionEnabled bool     `yaml:"recursionEnabled" envconfig:"DNS_RECURSION"`
-	RootHints        string   `yaml:"rootHints"        envconfig:"DNS_ROOT_HINTS"`
-	RootHintsFile    string   `yaml:"rootHintsFile"    envconfig:"DNS_ROOT_HINTS_FILE"`
-	FallbackServers  []string `yaml:"fallbackServers"  envconfig:"DNS_FALLBACK_SERVERS"`
+	ListenAddress    string `yaml:"address"          envconfig:"DNS_LISTEN_ADDRESS"`
+	ListenPort       uint   `yaml:"port"             envconfig:"DNS_LISTEN_PORT"`
+	ListenTlsPort    uint   `yaml:"tlsPort"          envconfig:"DNS_LISTEN_TLS_PORT"`
+	RecursionEnabled bool   `yaml:"recursionEnabled" envconfig:"DNS_RECURSION"`
+	RootHints        string `yaml:"rootHints"        envconfig:"DNS_ROOT_HINTS"`
+	RootHintsFile    string `yaml:"rootHintsFile"    envconfig:"DNS_ROOT_HINTS_FILE"`
 }
 
 type DebugConfig struct {
@@ -85,12 +84,6 @@ var globalConfig = &Config{
 		ListenPort:    8053,
 		ListenTlsPort: 8853,
 		RootHints:     string(defaultRootHints),
-		// hdns.io
-		FallbackServers: []string{
-			"103.196.38.38",
-			"103.196.38.39",
-			"103.196.38.40",
-		},
 	},
 	Debug: DebugConfig{
 		ListenAddress: "localhost",


### PR DESCRIPTION
This is no longer needed with ICANN root hints support

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed fallback DNS server support. The resolver now relies on ICANN root hints for recursion, simplifying config and code paths.

- **Refactors**
  - Removed DnsConfig.FallbackServers and default hdns.io servers.
  - Deleted fallback query path and randomFallbackServer().
  - doQuery now errors if no address is provided.

- **Migration**
  - Remove fallbackServers from config and DNS_FALLBACK_SERVERS env var.
  - If recursion is enabled, ensure RootHints or RootHintsFile is set.

<sup>Written for commit 50483a2b749b14b5088a9bdac30d32622a64bc45. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed automatic fallback to hardcoded DNS servers. DNS queries will no longer default to alternate servers if primary resolution fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->