### PR TITLE
feat: query retries

### DIFF
--- a/handshake/messages_test.go
+++ b/handshake/messages_test.go
@@ -81,7 +81,8 @@ func TestMsgVersionEncodeDecode(t *testing.T) {
 						0x0,
 						0x0,
 						0x0,
-					}},
+					},
+				},
 				Nonce: [8]uint8{
 					0x2d,
 					0xe9,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,9 @@ type DnsConfig struct {
 	RecursionEnabled bool      `yaml:"recursionEnabled" envconfig:"DNS_RECURSION"`
 	RootHints        string    `yaml:"rootHints"        envconfig:"DNS_ROOT_HINTS"`
 	RootHintsFile    string    `yaml:"rootHintsFile"    envconfig:"DNS_ROOT_HINTS_FILE"`
+	RetryCount       int       `yaml:"retryCount"       envconfig:"DNS_RETRY_COUNT"`
+	RetryDelayMs     int       `yaml:"retryDelayMs"     envconfig:"DNS_RETRY_DELAY_MS"`
+	QueryTimeoutMs   int       `yaml:"queryTimeoutMs"   envconfig:"DNS_QUERY_TIMEOUT_MS"`
 	SOA              SOAConfig `yaml:"soa"`
 }
 
@@ -90,10 +93,13 @@ var globalConfig = &Config{
 		QueryLog: true,
 	},
 	Dns: DnsConfig{
-		ListenAddress: "",
-		ListenPort:    8053,
-		ListenTlsPort: 8853,
-		RootHints:     string(defaultRootHints),
+		ListenAddress:  "",
+		ListenPort:     8053,
+		ListenTlsPort:  8853,
+		RootHints:      string(defaultRootHints),
+		RetryCount:     3,
+		RetryDelayMs:   100,
+		QueryTimeoutMs: 5000,
 		SOA: SOAConfig{
 			Mname:   "ns1.cdnsd.localhost.",
 			Rname:   "hostmaster.cdnsd.localhost.",
@@ -187,6 +193,16 @@ func Load(configFile string) (*Config, error) {
 			globalConfig.Indexer.InterceptHash = interceptHash
 			globalConfig.Indexer.InterceptSlot = interceptSlot
 		}
+	}
+	// Normalize retry/timeout fields
+	if globalConfig.Dns.RetryCount < 1 {
+		globalConfig.Dns.RetryCount = 1
+	}
+	if globalConfig.Dns.RetryDelayMs < 0 {
+		globalConfig.Dns.RetryDelayMs = 0
+	}
+	if globalConfig.Dns.QueryTimeoutMs <= 0 {
+		globalConfig.Dns.QueryTimeoutMs = 1
 	}
 	// Load root hints
 	if globalConfig.Dns.RootHintsFile != "" {

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -27,6 +27,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+var errMaxReferralDepth = errors.New(
+	"maximum referral depth reached",
+)
+
 var metricQueryTotal = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "dns_query_total",
 	Help: "total DNS queries handled",
@@ -527,24 +531,10 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 		if cfg.Dns.RecursionEnabled {
 			ctx := newResolutionContext()
 
-			// Pick random nameserver for domain
-			tmpNameserver := randomNameserverAddress(nameservers)
-			if tmpNameserver == nil {
-				m.SetRcode(r, dns.RcodeServerFailure)
-				if err := w.WriteMsg(m); err != nil {
-					slog.Error(
-						"unable to get nameserver",
-					)
-				}
-				slog.Error(
-					"unable to get nameserver",
-				)
-				return
-			}
-			// Query the random domain nameserver we picked above
-			resp, err := doQueryWithContext(
+			// Try all nameservers with retry and failover
+			resp, err := queryMultipleNameservers(
 				r,
-				net.JoinHostPort(tmpNameserver.String(), "53"),
+				nameservers,
 				true,
 				ctx,
 			)
@@ -553,23 +543,32 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 				m.SetRcode(r, dns.RcodeServerFailure)
 				if err := w.WriteMsg(m); err != nil {
 					slog.Error(
-						fmt.Sprintf("failed to write response: %s", err),
+						fmt.Sprintf(
+							"failed to write response: %s",
+							err,
+						),
 					)
 				}
 				slog.Error(
-					fmt.Sprintf("failed to query domain nameserver: %s", err),
+					fmt.Sprintf(
+						"recursive query failed: domain=%s, error=%s",
+						r.Question[0].Name,
+						err,
+					),
 				)
 				return
-			} else {
-				copyResponse(r, resp, m)
-				// Send response
-				if err := w.WriteMsg(m); err != nil {
-					slog.Error(
-						fmt.Sprintf("failed to write response: %s", err),
-					)
-				}
-				return
 			}
+			copyResponse(r, resp, m)
+			// Send response
+			if err := w.WriteMsg(m); err != nil {
+				slog.Error(
+					fmt.Sprintf(
+						"failed to write response: %s",
+						err,
+					),
+				)
+			}
+			return
 		} else {
 			for nameserver, addresses := range nameservers {
 				// NS record
@@ -657,40 +656,266 @@ func copyResponse(req *dns.Msg, srcResp *dns.Msg, destResp *dns.Msg) {
 	}
 }
 
-func randomNameserverAddress(nameservers map[string][]net.IP) net.IP {
-	// Put all namserver addresses in single list
-	tmpNameserversIpv4 := []net.IP{}
-	tmpNameserversIpv6 := []net.IP{}
-	for _, addresses := range nameservers {
-		for _, address := range addresses {
-			if ip := address.To4(); ip != nil {
-				tmpNameserversIpv4 = append(tmpNameserversIpv4, address)
+// queryWithRetry executes a query function with retries
+// and exponential backoff.
+func queryWithRetry(
+	queryFn func() (*dns.Msg, error),
+	maxRetries int,
+	baseDelay time.Duration,
+) (*dns.Msg, error) {
+	if maxRetries <= 0 {
+		maxRetries = 1
+	}
+	var lastErr error
+	for attempt := range maxRetries {
+		result, err := queryFn()
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		// Don't sleep after the last attempt
+		if attempt < maxRetries-1 {
+			// Exponential backoff: baseDelay * 2^attempt
+			delay := baseDelay * time.Duration(1<<attempt)
+			time.Sleep(delay)
+		}
+	}
+	return nil, fmt.Errorf(
+		"query failed after %d attempts: %w",
+		maxRetries,
+		lastErr,
+	)
+}
+
+// queryMultipleNameservers tries multiple nameservers until
+// one succeeds, using the default DNS port (53).
+func queryMultipleNameservers(
+	msg *dns.Msg,
+	nameservers map[string][]net.IP,
+	recursive bool,
+	ctx *resolutionContext,
+) (*dns.Msg, error) {
+	return queryMultipleNameserversWithPort(
+		msg,
+		nameservers,
+		recursive,
+		ctx,
+		"53",
+	)
+}
+
+// queryMultipleNameserversWithPort tries multiple nameservers
+// until one succeeds. It shuffles the nameserver order and
+// uses retry logic for each server.
+func queryMultipleNameserversWithPort(
+	msg *dns.Msg,
+	nameservers map[string][]net.IP,
+	recursive bool,
+	ctx *resolutionContext,
+	port string,
+) (*dns.Msg, error) {
+	cfg := config.GetConfig()
+
+	// Flatten nameservers into a list of addresses,
+	// preferring IPv4 over IPv6
+	ipv4Addrs := make([]string, 0)
+	ipv6Addrs := make([]string, 0)
+	for _, ips := range nameservers {
+		for _, ip := range ips {
+			if ip == nil {
+				continue
+			}
+			if ip.To4() != nil {
+				ipv4Addrs = append(
+					ipv4Addrs,
+					net.JoinHostPort(ip.String(), port),
+				)
 			} else {
-				tmpNameserversIpv6 = append(tmpNameserversIpv6, address)
+				ipv6Addrs = append(
+					ipv6Addrs,
+					net.JoinHostPort(ip.String(), port),
+				)
 			}
 		}
 	}
-	// Collect only IPv4 addresses unless we only have IPv6
-	// We can't guarantee that IPv6 works, so we try not to use it
-	var tmpNameservers []net.IP
-	if len(tmpNameserversIpv4) > 0 {
-		tmpNameservers = tmpNameserversIpv4
-	} else {
-		tmpNameservers = tmpNameserversIpv6
+
+	// Shuffle each group independently to distribute load
+	// while preserving IPv4-first preference
+	shuffleStrings(ipv4Addrs)
+	shuffleStrings(ipv6Addrs)
+
+	// Prefer IPv4, fall back to IPv6 if all IPv4 fail
+	addresses := make(
+		[]string,
+		0,
+		len(ipv4Addrs)+len(ipv6Addrs),
+	)
+	addresses = append(addresses, ipv4Addrs...)
+	addresses = append(addresses, ipv6Addrs...)
+
+	if len(addresses) == 0 {
+		return nil, errors.New("no nameserver addresses available")
 	}
-	if len(tmpNameservers) > 0 {
-		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(tmpNameservers))))
-		if err != nil {
-			return nil
+
+	var lastErr error
+	retryCount := cfg.Dns.RetryCount
+	if retryCount <= 0 {
+		retryCount = 1
+	}
+	baseDelay := time.Duration(
+		cfg.Dns.RetryDelayMs,
+	) * time.Millisecond
+	timeout := time.Duration(
+		cfg.Dns.QueryTimeoutMs,
+	) * time.Millisecond
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+
+	for _, addr := range addresses {
+		client := &dns.Client{
+			Timeout: timeout,
 		}
-		tmpNameserver := tmpNameservers[n.Int64()]
-		return tmpNameserver
+		queryFn := func() (*dns.Msg, error) {
+			resp, _, exchangeErr := client.Exchange(
+				msg,
+				addr,
+			)
+			if exchangeErr != nil {
+				return nil, exchangeErr
+			}
+			if resp == nil {
+				return nil, fmt.Errorf(
+					"nil response from %s",
+					addr,
+				)
+			}
+			// Treat SERVFAIL/REFUSED as retryable errors
+			if resp.Rcode == dns.RcodeServerFailure ||
+				resp.Rcode == dns.RcodeRefused {
+				return nil, fmt.Errorf(
+					"server %s returned %s",
+					addr,
+					dns.RcodeToString[resp.Rcode],
+				)
+			}
+			return resp, nil
+		}
+
+		resp, err := queryWithRetry(
+			queryFn,
+			retryCount,
+			baseDelay,
+		)
+		if err != nil {
+			slog.Debug(
+				fmt.Sprintf(
+					"nameserver query failed: address=%s, error=%s",
+					addr,
+					err,
+				),
+			)
+			lastErr = err
+			continue
+		}
+
+		// If recursive and got a referral, follow it
+		if recursive &&
+			!resp.Authoritative &&
+			len(resp.Ns) > 0 {
+			result, referralErr := handleReferral(
+				msg,
+				resp,
+				ctx,
+			)
+			if referralErr == nil {
+				return result, nil
+			}
+			slog.Debug(
+				fmt.Sprintf(
+					"referral failed: address=%s, error=%s",
+					addr,
+					referralErr,
+				),
+			)
+			lastErr = referralErr
+			continue
+		}
+
+		return resp, nil
 	}
-	return nil
+
+	return nil, fmt.Errorf(
+		"all nameservers failed: %w",
+		lastErr,
+	)
 }
 
-// doQueryWithContext performs a DNS query with resolution context for depth tracking.
-// It wraps the existing doQuery logic with context awareness.
+// shuffleStrings randomly reorders a slice of strings
+// using crypto/rand.
+func shuffleStrings(s []string) {
+	for i := len(s) - 1; i > 0; i-- {
+		n, err := rand.Int(
+			rand.Reader,
+			big.NewInt(int64(i+1)),
+		)
+		if err != nil || n == nil {
+			continue
+		}
+		j := n.Int64()
+		s[i], s[j] = s[j], s[i]
+	}
+}
+
+// handleReferral processes a DNS referral response and
+// follows the delegation.
+func handleReferral(
+	msg *dns.Msg,
+	resp *dns.Msg,
+	ctx *resolutionContext,
+) (*dns.Msg, error) {
+	if ctx.atMaxDepth() {
+		return nil, errMaxReferralDepth
+	}
+
+	nameservers := getNameserversFromResponse(resp)
+	if len(nameservers) == 0 {
+		return resp, nil
+	}
+
+	// Resolve missing glue records
+	childCtx := ctx.descend()
+	for nsName, nsIPs := range nameservers {
+		if len(nsIPs) == 0 {
+			resolvedIPs, err := resolveNameserverAddress(
+				nsName,
+				childCtx,
+			)
+			if err != nil {
+				slog.Debug(
+					fmt.Sprintf(
+						"failed to resolve NS glue: ns=%s, error=%s",
+						nsName,
+						err,
+					),
+				)
+				continue
+			}
+			nameservers[nsName] = resolvedIPs
+		}
+	}
+
+	return queryMultipleNameservers(
+		msg,
+		nameservers,
+		true,
+		childCtx,
+	)
+}
+
+// doQueryWithContext performs a DNS query with resolution
+// context for depth tracking. It uses retry logic and
+// configurable timeouts.
 func doQueryWithContext(
 	msg *dns.Msg,
 	address string,
@@ -701,92 +926,33 @@ func doQueryWithContext(
 		return nil, errors.New("max resolution depth exceeded")
 	}
 
-	// Add default port if not specified
-	if _, _, err := net.SplitHostPort(address); err != nil {
-		address = net.JoinHostPort(address, "53")
-	}
-
-	resp, err := dns.Exchange(msg, address)
+	// Parse host and port, defaulting to port 53
+	host, port, err := net.SplitHostPort(address)
 	if err != nil {
-		return nil, err
+		// No port specified, treat as host-only
+		host = address
+		port = "53"
 	}
-	if resp == nil {
-		return nil, fmt.Errorf("received nil response from %s", address)
-	}
-
-	// If we got an authoritative answer or non-recursive mode, return
-	if resp.Authoritative || !recursive {
-		return resp, nil
-	}
-
-	// Handle referrals (NS records in authority section)
-	if len(resp.Ns) > 0 {
-		nameservers := getNameserversFromResponse(resp)
-		if nameservers == nil {
-			return resp, nil
-		}
-
-		// Try to resolve missing glue records
-		childCtx := ctx.descend()
-		for nsName, nsIPs := range nameservers {
-			if len(nsIPs) == 0 {
-				resolvedIPs, err := resolveNameserverAddress(nsName, childCtx)
-				if err != nil {
-					slog.Debug(
-						fmt.Sprintf(
-							"failed to resolve NS address: ns=%s, error=%s",
-							nsName,
-							err,
-						),
-					)
-					continue
-				}
-				nameservers[nsName] = resolvedIPs
-			}
-		}
-
-		// Pick a random nameserver that has addresses
-		availableNS := make([]string, 0, len(nameservers))
-		for nsName, nsIPs := range nameservers {
-			if len(nsIPs) > 0 {
-				availableNS = append(availableNS, nsName)
-			}
-		}
-
-		if len(availableNS) > 0 {
-			n, err := rand.Int(rand.Reader, big.NewInt(int64(len(availableNS))))
-			if err != nil {
-				return nil, fmt.Errorf("random selection failed: %w", err)
-			}
-			randNS := availableNS[n.Int64()]
-			nsIPs := nameservers[randNS]
-			if len(nsIPs) == 0 {
-				return resp, nil
-			}
-			randIP := nsIPs[0]
-			if len(nsIPs) > 1 {
-				ipIdx, err := rand.Int(
-					rand.Reader,
-					big.NewInt(int64(len(nsIPs))),
-				)
-				if err != nil {
-					return nil, fmt.Errorf(
-						"random IP selection failed: %w",
-						err,
-					)
-				}
-				randIP = nsIPs[ipIdx.Int64()]
-			}
-			return doQueryWithContext(
-				msg,
-				net.JoinHostPort(randIP.String(), "53"),
-				recursive,
-				childCtx,
-			)
-		}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil, fmt.Errorf(
+			"invalid IP address: %s",
+			host,
+		)
 	}
 
-	return resp, nil
+	// Create nameserver map with single entry
+	nameservers := map[string][]net.IP{
+		"initial": {ip},
+	}
+
+	return queryMultipleNameserversWithPort(
+		msg,
+		nameservers,
+		recursive,
+		ctx,
+		port,
+	)
 }
 
 func findNameserversForDomain(

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -8,7 +8,9 @@ package dns
 
 import (
 	"fmt"
+	"net"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -442,5 +444,393 @@ func TestSOAConfigDefaults(t *testing.T) {
 	}
 	if soaCfg.Minimum == 0 {
 		t.Error("expected non-zero SOA minimum default")
+	}
+}
+
+func TestQueryWithRetry(t *testing.T) {
+	attempts := 0
+	mockQuery := func() (*dns.Msg, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, fmt.Errorf(
+				"simulated failure %d",
+				attempts,
+			)
+		}
+		return &dns.Msg{}, nil
+	}
+
+	result, err := queryWithRetry(
+		mockQuery,
+		3,
+		10*time.Millisecond,
+	)
+	if err != nil {
+		t.Errorf(
+			"expected success after retries, got: %v",
+			err,
+		)
+	}
+	if result == nil {
+		t.Error("expected non-nil result")
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestQueryWithRetryExhausted(t *testing.T) {
+	attempts := 0
+	mockQuery := func() (*dns.Msg, error) {
+		attempts++
+		return nil, fmt.Errorf("always fails")
+	}
+
+	result, err := queryWithRetry(
+		mockQuery,
+		3,
+		10*time.Millisecond,
+	)
+	if err == nil {
+		t.Error("expected error when retries exhausted")
+	}
+	if result != nil {
+		t.Error("expected nil result on failure")
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestQueryWithRetryFirstAttemptSuccess(t *testing.T) {
+	attempts := 0
+	mockQuery := func() (*dns.Msg, error) {
+		attempts++
+		return &dns.Msg{}, nil
+	}
+
+	result, err := queryWithRetry(
+		mockQuery,
+		3,
+		10*time.Millisecond,
+	)
+	if err != nil {
+		t.Errorf("expected success, got: %v", err)
+	}
+	if result == nil {
+		t.Error("expected non-nil result")
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt, got %d", attempts)
+	}
+}
+
+// startTestDNSServer starts a local UDP DNS server on the
+// given address with the given handler and returns its IP
+// and port. The server is shut down when the test completes.
+// Use "127.0.0.1:0" for a random port or specify a port.
+func startTestDNSServer(
+	t *testing.T,
+	addr string,
+	handler dns.Handler,
+) (net.IP, string) {
+	t.Helper()
+	srv := &dns.Server{
+		Net:     "udp",
+		Handler: handler,
+	}
+	pc, err := net.ListenPacket("udp", addr)
+	if err != nil {
+		t.Fatalf("failed to listen on %s: %v", addr, err)
+	}
+	srv.PacketConn = pc
+	go func() { _ = srv.ActivateAndServe() }()
+	t.Cleanup(func() { srv.Shutdown() })
+
+	localAddr := pc.LocalAddr()
+	if localAddr == nil {
+		t.Fatal("failed to get local address")
+	}
+	host, port, err := net.SplitHostPort(
+		localAddr.String(),
+	)
+	if err != nil {
+		t.Fatalf("failed to parse address: %v", err)
+	}
+	return net.ParseIP(host), port
+}
+
+// successHandler returns a DNS handler that responds with
+// a single A record for any query.
+func successHandler() dns.Handler {
+	return dns.HandlerFunc(
+		func(w dns.ResponseWriter, r *dns.Msg) {
+			resp := new(dns.Msg)
+			resp.SetReply(r)
+			resp.Answer = append(resp.Answer, &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   r.Question[0].Name,
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    60,
+				},
+				A: net.ParseIP("127.0.0.1"),
+			})
+			_ = w.WriteMsg(resp)
+		},
+	)
+}
+
+func TestQueryMultipleNameservers(t *testing.T) {
+	ip1, port1 := startTestDNSServer(
+		t, "127.0.0.1:0", successHandler(),
+	)
+	// Start second server on same port but different IP
+	ip2, _ := startTestDNSServer(
+		t, "127.0.0.2:"+port1, successHandler(),
+	)
+
+	nameservers := map[string][]net.IP{
+		"resolver1.": {ip1},
+		"resolver2.": {ip2},
+	}
+
+	ctx := newResolutionContext()
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+
+	resp, err := queryMultipleNameserversWithPort(
+		msg,
+		nameservers,
+		false,
+		ctx,
+		port1,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Error("expected response")
+	}
+}
+
+func TestQueryMultipleNameserversFailover(t *testing.T) {
+	// Failing server: returns SERVFAIL
+	badHandler := dns.HandlerFunc(
+		func(w dns.ResponseWriter, r *dns.Msg) {
+			resp := new(dns.Msg)
+			resp.SetReply(r)
+			resp.Rcode = dns.RcodeServerFailure
+			_ = w.WriteMsg(resp)
+		},
+	)
+
+	badIP, port := startTestDNSServer(
+		t, "127.0.0.1:0", badHandler,
+	)
+	goodIP, _ := startTestDNSServer(
+		t, "127.0.0.2:"+port, successHandler(),
+	)
+
+	nameservers := map[string][]net.IP{
+		"bad.":  {badIP},
+		"good.": {goodIP},
+	}
+
+	cfg := config.GetConfig()
+	origTimeout := cfg.Dns.QueryTimeoutMs
+	origRetry := cfg.Dns.RetryCount
+	cfg.Dns.QueryTimeoutMs = 500
+	cfg.Dns.RetryCount = 1
+	defer func() {
+		cfg.Dns.QueryTimeoutMs = origTimeout
+		cfg.Dns.RetryCount = origRetry
+	}()
+
+	ctx := newResolutionContext()
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+
+	resp, err := queryMultipleNameserversWithPort(
+		msg,
+		nameservers,
+		false,
+		ctx,
+		port,
+	)
+	if err != nil {
+		t.Fatalf("expected fallback success, got: %v", err)
+	}
+	if resp == nil {
+		t.Error("expected response from fallback nameserver")
+	}
+}
+
+func TestQueryMultipleNameserversNoAddresses(t *testing.T) {
+	ctx := newResolutionContext()
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+
+	nameservers := map[string][]net.IP{}
+
+	_, err := queryMultipleNameservers(
+		msg,
+		nameservers,
+		false,
+		ctx,
+	)
+	if err == nil {
+		t.Error("expected error with no nameservers")
+	}
+}
+
+func TestQueryTimeoutRespected(t *testing.T) {
+	cfg := config.GetConfig()
+	origTimeout := cfg.Dns.QueryTimeoutMs
+	origRetry := cfg.Dns.RetryCount
+	origDelay := cfg.Dns.RetryDelayMs
+	cfg.Dns.QueryTimeoutMs = 100
+	cfg.Dns.RetryCount = 1
+	cfg.Dns.RetryDelayMs = 10
+	defer func() {
+		cfg.Dns.QueryTimeoutMs = origTimeout
+		cfg.Dns.RetryCount = origRetry
+		cfg.Dns.RetryDelayMs = origDelay
+	}()
+
+	ctx := newResolutionContext()
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+
+	start := time.Now()
+	_, err := doQueryWithContext(
+		msg,
+		"192.0.2.1:53",
+		false,
+		ctx,
+	)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Skip(
+			"unexpectedly got response from TEST-NET address",
+		)
+	}
+
+	// Should timeout within reasonable time
+	maxExpected := 2 * time.Second
+	if elapsed > maxExpected {
+		t.Errorf(
+			"query took too long: %v (expected < %v)",
+			elapsed,
+			maxExpected,
+		)
+	}
+}
+
+func TestServfailRetriedBeforeFailover(t *testing.T) {
+	var attempts atomic.Int32
+	// Start a DNS server that returns SERVFAIL once,
+	// then succeeds on retry.
+	handler := dns.HandlerFunc(
+		func(w dns.ResponseWriter, r *dns.Msg) {
+			n := attempts.Add(1)
+			resp := new(dns.Msg)
+			resp.SetReply(r)
+			if n < 2 {
+				resp.Rcode = dns.RcodeServerFailure
+			}
+			_ = w.WriteMsg(resp)
+		},
+	)
+
+	srv := &dns.Server{
+		Addr:    "127.0.0.1:0",
+		Net:     "udp",
+		Handler: handler,
+	}
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	srv.PacketConn = pc
+	go func() { _ = srv.ActivateAndServe() }()
+	defer srv.Shutdown()
+
+	localAddr := pc.LocalAddr()
+	if localAddr == nil {
+		t.Fatal("failed to get local address")
+	}
+	addr := localAddr.String()
+
+	cfg := config.GetConfig()
+	origTimeout := cfg.Dns.QueryTimeoutMs
+	origRetry := cfg.Dns.RetryCount
+	origDelay := cfg.Dns.RetryDelayMs
+	cfg.Dns.QueryTimeoutMs = 1000
+	cfg.Dns.RetryCount = 3
+	cfg.Dns.RetryDelayMs = 10
+	defer func() {
+		cfg.Dns.QueryTimeoutMs = origTimeout
+		cfg.Dns.RetryCount = origRetry
+		cfg.Dns.RetryDelayMs = origDelay
+	}()
+
+	ctx := newResolutionContext()
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeA)
+
+	resp, err := doQueryWithContext(
+		msg,
+		addr,
+		false,
+		ctx,
+	)
+	if err != nil {
+		t.Fatalf("expected success after retry, got: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Errorf(
+			"expected NOERROR, got %s",
+			dns.RcodeToString[resp.Rcode],
+		)
+	}
+	finalAttempts := attempts.Load()
+	if finalAttempts < 2 {
+		t.Errorf(
+			"expected at least 2 attempts, got %d",
+			finalAttempts,
+		)
+	}
+}
+
+func TestShuffleStrings(t *testing.T) {
+	// Verify shuffle doesn't lose elements
+	input := []string{"a", "b", "c", "d", "e"}
+	original := make([]string, len(input))
+	copy(original, input)
+
+	shuffleStrings(input)
+
+	if len(input) != len(original) {
+		t.Errorf(
+			"shuffle changed length: got %d, want %d",
+			len(input),
+			len(original),
+		)
+	}
+
+	// Verify all elements still present
+	seen := make(map[string]bool, len(input))
+	for _, s := range input {
+		seen[s] = true
+	}
+	for _, s := range original {
+		if !seen[s] {
+			t.Errorf("element %q lost after shuffle", s)
+		}
 	}
 }


### PR DESCRIPTION
Closes #479 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable DNS query retries with exponential backoff, per-query timeouts, and IPv4-first shuffled multi-nameserver failover to make recursion more reliable. Retries on `SERVFAIL`/`REFUSED` before failing over; addresses #479.

- **New Features**
  - Config: `retryCount`, `retryDelayMs`, `queryTimeoutMs` (env: `DNS_RETRY_COUNT`, `DNS_RETRY_DELAY_MS`, `DNS_QUERY_TIMEOUT_MS`) with defaults 3/100ms/5000ms and normalization (min retry 1, non-negative delay, min timeout 1ms).
  - Retry/failover engine with exponential backoff and `dns.Client` timeouts; IPv4-first shuffled server order; referral following with glue resolution and a max-depth guard; retriable `SERVFAIL`/`REFUSED` before trying the next server.

- **Refactors**
  - Recursive resolver now tries all nameservers with retry/failover; removed random single-NS pick and tightened logs.
  - `doQueryWithContext` parses `host:port`, validates IPs, defaults to port 53, and delegates to the multi-NS logic.

<sup>Written for commit fd8ba5c01df60f8673da6d08d94209c8467a078a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable DNS retry behavior (defaults: 3 retries, 100ms delay, 5000ms timeout); multi-nameserver failover, IPv4-preferred addressing, randomized server/address ordering, exponential backoff and improved referral handling for more resilient recursive resolution.

* **Tests**
  * Added comprehensive tests covering retries, failover, timeouts, deterministic shuffling, and referral scenarios.

* **Style**
  * Minor test formatting adjustment with no behavioral change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->