### PR TITLE
chore: update go version to 1.25

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: '0'
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
       - name: Upload release asset

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/blinklabs-io/cdnsd
 
-go 1.24.0
-
-toolchain go1.24.4
+go 1.25.7
 
 require (
 	github.com/blinklabs-io/adder v0.37.0


### PR DESCRIPTION
Closes #546 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Go versions across CI and module: tests run on 1.25.x and 1.26.x, `nilaway` and publish workflows use 1.25.x, and `go.mod` targets Go 1.25.7 (removed toolchain directive). Drops 1.24.x to align with supported versions (Linear 546).

<sup>Written for commit 30532700e74734b81ef0a67551dfe800e3ef7e68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use newer Go toolchain versions for testing and publishing.
  * Bumped project Go toolchain declaration to a newer release for builds.
  * No functional code changes; build and release processes updated to align with current toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->