### PR TITLE
fix: handle malformed DNS queries

### DIFF
--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -409,9 +409,14 @@ func startListener(server *dns.Server) {
 }
 
 func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
-	if r.Question == nil {
+	if r == nil {
 		return
 	}
+	if len(r.Question) != 1 {
+		writeFormatError(w, r)
+		return
+	}
+
 	cfg := config.GetConfig()
 	m := new(dns.Msg)
 
@@ -615,6 +620,19 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 	if zone != "" {
 		m.Ns = append(m.Ns, generateSyntheticSOA(zone))
 	}
+	if err := w.WriteMsg(m); err != nil {
+		slog.Error(
+			fmt.Sprintf("failed to write response: %s", err),
+		)
+	}
+}
+
+func writeFormatError(w dns.ResponseWriter, r *dns.Msg) {
+	if w == nil || r == nil {
+		return
+	}
+	m := new(dns.Msg)
+	m.SetRcodeFormatError(r)
 	if err := w.WriteMsg(m); err != nil {
 		slog.Error(
 			fmt.Sprintf("failed to write response: %s", err),

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -83,6 +83,128 @@ func stateIsLoaded() bool {
 	return loaded
 }
 
+type captureResponseWriter struct {
+	msg *dns.Msg
+	raw []byte
+}
+
+func (w *captureResponseWriter) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 53}
+}
+
+func (w *captureResponseWriter) RemoteAddr() net.Addr {
+	return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}
+}
+
+func (w *captureResponseWriter) WriteMsg(msg *dns.Msg) error {
+	w.msg = msg.Copy()
+	return nil
+}
+
+func (w *captureResponseWriter) Write(raw []byte) (int, error) {
+	w.raw = append([]byte(nil), raw...)
+	return len(raw), nil
+}
+
+func (w *captureResponseWriter) Close() error {
+	return nil
+}
+
+func (w *captureResponseWriter) TsigStatus() error {
+	return nil
+}
+
+func (w *captureResponseWriter) TsigTimersOnly(bool) {}
+
+func (w *captureResponseWriter) Hijack() {}
+
+func TestHandleQueryMalformedQuestionCounts(t *testing.T) {
+	question := dns.Question{
+		Name:   "example.com.",
+		Qtype:  dns.TypeA,
+		Qclass: dns.ClassINET,
+	}
+	testCases := []struct {
+		name      string
+		questions []dns.Question
+	}{
+		{
+			name:      "nil questions",
+			questions: nil,
+		},
+		{
+			name:      "empty questions",
+			questions: []dns.Question{},
+		},
+		{
+			name: "multiple questions",
+			questions: []dns.Question{
+				question,
+				{
+					Name:   "example.net.",
+					Qtype:  dns.TypeAAAA,
+					Qclass: dns.ClassINET,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &dns.Msg{
+				MsgHdr: dns.MsgHdr{
+					Id:               1234,
+					RecursionDesired: true,
+				},
+				Question: tc.questions,
+			}
+			w := &captureResponseWriter{}
+
+			handleQuery(w, req)
+
+			if w.msg == nil {
+				t.Fatal("expected response")
+			}
+			if w.msg.Id != req.Id {
+				t.Errorf(
+					"expected response id %d, got %d",
+					req.Id,
+					w.msg.Id,
+				)
+			}
+			if !w.msg.Response {
+				t.Error("expected response bit to be set")
+			}
+			if w.msg.Rcode != dns.RcodeFormatError {
+				t.Errorf(
+					"expected FORMERR, got %s",
+					dns.RcodeToString[w.msg.Rcode],
+				)
+			}
+			if len(w.msg.Question) != 0 {
+				t.Errorf(
+					"expected no echoed questions, got %d",
+					len(w.msg.Question),
+				)
+			}
+		})
+	}
+}
+
+func TestHandleQueryNilRequestDoesNotPanic(t *testing.T) {
+	w := &captureResponseWriter{}
+	defer func() {
+		if err := recover(); err != nil {
+			t.Fatalf("handleQuery panicked: %v", err)
+		}
+		if w.msg != nil {
+			t.Fatal("expected no response for nil request")
+		}
+	}()
+
+	handleQuery(w, nil)
+}
+
 func TestResolveNameserverAddressFromLocal(t *testing.T) {
 	// This test requires state to be initialized with a database
 	// Skip if state not available (will be tested via integration)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Safely handle malformed DNS queries by returning FORMERR when the question count is not exactly one, and avoid panics on nil requests. This improves protocol compliance and stability in the DNS server.

- **Bug Fixes**
  - Return FORMERR with no echoed questions when a query has zero or multiple questions.
  - Handle nil requests without panicking; added writeFormatError helper to send FORMERR and log write errors.

<sup>Written for commit 39054d46c272e6683a4d15250cf01f0e8ee7d6c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cdnsd/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - DNS requests are now validated more strictly, returning a format error for malformed queries instead of failing silently.
  - Nil DNS requests are handled safely without causing a crash.

- **Tests**
  - Added coverage for malformed query counts, including nil, empty, and multiple-question requests.
  - Added a test to confirm nil requests do not panic and do not generate a response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->