### PR TITLE
fix: application lifecycle and shutdown

### DIFF
--- a/cmd/cdnsd/main.go
+++ b/cmd/cdnsd/main.go
@@ -7,12 +7,17 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	_ "net/http/pprof" // #nosec G108
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/blinklabs-io/cdnsd/internal/config"
@@ -29,11 +34,17 @@ var cmdlineFlags struct {
 	configFile string
 }
 
+const shutdownTimeout = 15 * time.Second
+
 func slogPrintf(format string, v ...any) {
 	slog.Info(fmt.Sprintf(format, v...))
 }
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	flag.StringVar(
 		&cmdlineFlags.configFile,
 		"config",
@@ -42,11 +53,26 @@ func main() {
 	)
 	flag.Parse()
 
+	signalCtx, stopSignals := signal.NotifyContext(
+		context.Background(),
+		os.Interrupt,
+		syscall.SIGTERM,
+	)
+	defer stopSignals()
+	signalReceived := func() bool {
+		select {
+		case <-signalCtx.Done():
+			return true
+		default:
+			return false
+		}
+	}
+
 	// Load config
 	cfg, err := config.Load(cmdlineFlags.configFile)
 	if err != nil {
 		fmt.Printf("Failed to load config: %s\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	// Configure logger
@@ -59,7 +85,7 @@ func main() {
 	if err != nil {
 		// If we hit this, something really wrong happened
 		logger.Error(err.Error())
-		os.Exit(1)
+		return 1
 	}
 
 	slog.Info(
@@ -67,15 +93,54 @@ func main() {
 	)
 
 	// Load state
-	if err := state.GetState().Load(); err != nil {
+	stateStore := state.GetState()
+	if err := stateStore.Load(); err != nil {
 		slog.Error(
 			fmt.Sprintf("failed to load state: %s", err),
 		)
-		os.Exit(1)
+		return 1
+	}
+
+	asyncErrCh := make(chan error, 8)
+	indexerSvc := indexer.GetIndexer()
+	var dnsSrv *dns.Server
+	var debugSrv *http.Server
+	var metricsSrv *http.Server
+	shutdown := func() error {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(),
+			shutdownTimeout,
+		)
+		defer cancel()
+		return shutdownServices(
+			shutdownCtx,
+			dnsSrv,
+			debugSrv,
+			metricsSrv,
+			indexerSvc,
+			stateStore,
+		)
+	}
+	shutdownAfterSignal := func() int {
+		slog.Info("shutdown signal received")
+		stopSignals()
+		if err := shutdown(); err != nil {
+			slog.Error("shutdown failed", "error", err)
+			return 1
+		}
+		return 0
+	}
+	if signalReceived() {
+		return shutdownAfterSignal()
 	}
 
 	// Start debug listener
 	if cfg.Debug.ListenPort > 0 {
+		debugListenAddr := fmt.Sprintf(
+			"%s:%d",
+			cfg.Debug.ListenAddress,
+			cfg.Debug.ListenPort,
+		)
 		slog.Info(
 			fmt.Sprintf(
 				"starting debug listener on %s:%d",
@@ -83,23 +148,18 @@ func main() {
 				cfg.Debug.ListenPort,
 			),
 		)
-		go func() {
-			debugger := &http.Server{
-				Addr: fmt.Sprintf(
-					"%s:%d",
-					cfg.Debug.ListenAddress,
-					cfg.Debug.ListenPort,
-				),
-				ReadHeaderTimeout: 60 * time.Second,
-			}
-			err := debugger.ListenAndServe()
-			if err != nil {
-				slog.Error(
-					fmt.Sprintf("failed to start debug listener: %s", err),
-				)
-				os.Exit(1)
-			}
-		}()
+		debugSrv = &http.Server{
+			Addr:              debugListenAddr,
+			ReadHeaderTimeout: 60 * time.Second,
+		}
+		if err := startHTTPServer("debug", debugSrv, asyncErrCh); err != nil {
+			slog.Error(err.Error())
+			_ = shutdown()
+			return 1
+		}
+		if signalReceived() {
+			return shutdownAfterSignal()
+		}
 	}
 
 	// Start metrics listener
@@ -114,38 +174,137 @@ func main() {
 		)
 		metricsMux := http.NewServeMux()
 		metricsMux.Handle("/metrics", promhttp.Handler())
-		metricsSrv := &http.Server{
+		metricsSrv = &http.Server{
 			Addr:         metricsListenAddr,
 			WriteTimeout: 10 * time.Second,
 			ReadTimeout:  10 * time.Second,
 			Handler:      metricsMux,
 		}
-		go func() {
-			if err := metricsSrv.ListenAndServe(); err != nil {
-				slog.Error(
-					fmt.Sprintf("failed to start metrics listener: %s", err),
-				)
-				os.Exit(1)
-			}
-		}()
+		if err := startHTTPServer("metrics", metricsSrv, asyncErrCh); err != nil {
+			slog.Error(err.Error())
+			_ = shutdown()
+			return 1
+		}
+		if signalReceived() {
+			return shutdownAfterSignal()
+		}
 	}
 
 	// Start indexer
-	if err := indexer.GetIndexer().Start(); err != nil {
+	if err := indexerSvc.Start(); err != nil {
 		slog.Error(
 			fmt.Sprintf("failed to start indexer: %s", err),
 		)
-		os.Exit(1)
+		_ = shutdown()
+		return 1
+	}
+	if signalReceived() {
+		return shutdownAfterSignal()
 	}
 
 	// Start DNS listener
-	if err := dns.Start(); err != nil {
+	dnsSrv, err = dns.Start()
+	if err != nil {
 		slog.Error(
 			fmt.Sprintf("failed to start DNS listener: %s", err),
 		)
-		os.Exit(1)
+		_ = shutdown()
+		return 1
+	}
+	if signalReceived() {
+		return shutdownAfterSignal()
 	}
 
-	// Wait forever
-	select {}
+	var runtimeErr error
+	select {
+	case <-signalCtx.Done():
+		slog.Info("shutdown signal received")
+	case err := <-asyncErrCh:
+		runtimeErr = err
+		slog.Error("runtime failure", "error", err)
+	case err := <-indexerSvc.Errors():
+		runtimeErr = err
+		slog.Error("runtime failure", "error", err)
+	case err := <-dnsSrv.Errors():
+		runtimeErr = err
+		slog.Error("runtime failure", "error", err)
+	}
+	stopSignals()
+
+	if err := shutdown(); err != nil {
+		slog.Error("shutdown failed", "error", err)
+		if runtimeErr == nil {
+			runtimeErr = err
+		}
+	}
+	if runtimeErr != nil {
+		return 1
+	}
+	return 0
+}
+
+func startHTTPServer(
+	name string,
+	srv *http.Server,
+	errCh chan<- error,
+) error {
+	listener, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		return fmt.Errorf("failed to start %s listener: %w", name, err)
+	}
+	go func() {
+		if err := srv.Serve(listener); err != nil &&
+			!errors.Is(err, http.ErrServerClosed) {
+			reportAsyncErr(
+				errCh,
+				fmt.Errorf("%s listener failed: %w", name, err),
+			)
+		}
+	}()
+	return nil
+}
+
+func reportAsyncErr(errCh chan<- error, err error) {
+	select {
+	case errCh <- err:
+	default:
+		slog.Error("runtime failure", "error", err)
+	}
+}
+
+func shutdownServices(
+	ctx context.Context,
+	dnsSrv *dns.Server,
+	debugSrv *http.Server,
+	metricsSrv *http.Server,
+	indexerSvc *indexer.Indexer,
+	stateStore *state.State,
+) error {
+	var errs []error
+	if dnsSrv != nil {
+		if err := dnsSrv.Shutdown(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("stop DNS listener: %w", err))
+		}
+	}
+	if debugSrv != nil {
+		if err := debugSrv.Shutdown(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("stop debug listener: %w", err))
+		}
+	}
+	if metricsSrv != nil {
+		if err := metricsSrv.Shutdown(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("stop metrics listener: %w", err))
+		}
+	}
+	if indexerSvc != nil {
+		if err := indexerSvc.Stop(); err != nil {
+			errs = append(errs, fmt.Errorf("stop indexer: %w", err))
+		}
+	}
+	if stateStore != nil {
+		if err := stateStore.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close state: %w", err))
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -7,6 +7,7 @@
 package dns
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/tls"
 	"errors"
@@ -15,10 +16,10 @@ import (
 	"maps"
 	"math/big"
 	"net"
-	"os"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blinklabs-io/cdnsd/internal/config"
@@ -193,6 +194,57 @@ func (r *Resolver) resolveNameserverAddress(
 	return ips, nil
 }
 
+// Server owns the DNS listeners started by Start.
+type Server struct {
+	servers []*dns.Server
+	errCh   chan error
+
+	stopOnce sync.Once
+	stopErr  error
+}
+
+// Errors returns asynchronous listener failures.
+func (s *Server) Errors() <-chan error {
+	if s == nil {
+		return nil
+	}
+	return s.errCh
+}
+
+// Shutdown gracefully stops all DNS listeners.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.stopOnce.Do(func() {
+		var errs []error
+		for _, server := range s.servers {
+			if err := server.ShutdownContext(ctx); err != nil && !isServerNotStarted(err) {
+				errs = append(errs, err)
+			}
+		}
+		s.stopErr = errors.Join(errs...)
+	})
+	return s.stopErr
+}
+
+// Close stops all DNS listeners without a deadline.
+func (s *Server) Close() error {
+	return s.Shutdown(context.Background())
+}
+
+func (s *Server) reportError(err error) {
+	select {
+	case s.errCh <- err:
+	default:
+		slog.Error("DNS listener error", "error", err)
+	}
+}
+
+func isServerNotStarted(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "server not started")
+}
+
 // getRandomRootServer returns a random root server address from hints
 func (r *Resolver) getRandomRootServer() string {
 	if r == nil || r.rootHints == nil {
@@ -343,7 +395,7 @@ func findZoneForName(name string) string {
 	return ""
 }
 
-func Start() error {
+func Start() (*Server, error) {
 	cfg := config.GetConfig()
 	listenAddr := fmt.Sprintf(
 		"%s:%d",
@@ -355,14 +407,15 @@ func Start() error {
 	)
 	resolver, err := NewResolver(cfg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	tlsConfig, err := loadConfiguredTLSConfig(cfg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	mux := dns.NewServeMux()
 	mux.HandleFunc(".", resolver.handleQuery)
+	servers := []*dns.Server{}
 	// UDP listener
 	serverUdp := &dns.Server{
 		Addr:       listenAddr,
@@ -371,7 +424,7 @@ func Start() error {
 		TsigSecret: nil,
 		ReusePort:  true,
 	}
-	go startListener(serverUdp)
+	servers = append(servers, serverUdp)
 	// TCP listener
 	serverTcp := &dns.Server{
 		Addr:       listenAddr,
@@ -380,7 +433,7 @@ func Start() error {
 		TsigSecret: nil,
 		ReusePort:  true,
 	}
-	go startListener(serverTcp)
+	servers = append(servers, serverTcp)
 	// TLS listener
 	if tlsConfig != nil {
 		listenTlsAddr := fmt.Sprintf(
@@ -396,7 +449,38 @@ func Start() error {
 			TLSConfig:  tlsConfig,
 			ReusePort:  false,
 		}
-		go startListener(serverTls)
+		servers = append(servers, serverTls)
+	}
+	server := &Server{
+		servers: servers,
+		errCh:   make(chan error, len(servers)),
+	}
+	if err := startDNSListeners(server, servers); err != nil {
+		return nil, err
+	}
+	return server, nil
+}
+
+func startDNSListeners(server *Server, servers []*dns.Server) error {
+	startedServers := make([]*dns.Server, 0, len(servers))
+	for _, listener := range servers {
+		readyCh := make(chan struct{})
+		startupErrCh := make(chan error, 1)
+		var readyOnce sync.Once
+		listener.NotifyStartedFunc = func() {
+			readyOnce.Do(func() {
+				close(readyCh)
+			})
+		}
+		go startListener(server, listener, readyCh, startupErrCh)
+		select {
+		case <-readyCh:
+			startedServers = append(startedServers, listener)
+		case err := <-startupErrCh:
+			server.servers = startedServers
+			_ = server.Close()
+			return err
+		}
 	}
 	return nil
 }
@@ -429,6 +513,7 @@ func loadTLSConfig(
 	}
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
 	}, nil
 }
 
@@ -454,12 +539,24 @@ func (r *Resolver) loadRootHints(cfg *config.Config) error {
 	return nil
 }
 
-func startListener(server *dns.Server) {
-	if err := server.ListenAndServe(); err != nil {
-		slog.Error(
-			fmt.Sprintf("failed to start DNS listener: %s", err),
-		)
-		os.Exit(1)
+func startListener(
+	server *Server,
+	listener *dns.Server,
+	readyCh <-chan struct{},
+	startupErrCh chan<- error,
+) {
+	if err := listener.ListenAndServe(); err != nil {
+		err = fmt.Errorf("DNS %s listener failed: %w", listener.Net, err)
+		select {
+		case <-readyCh:
+			server.reportError(err)
+		default:
+			select {
+			case startupErrCh <- err:
+			default:
+				server.reportError(err)
+			}
+		}
 	}
 }
 

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -8,10 +8,12 @@ package dns
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -27,6 +29,84 @@ import (
 	"github.com/blinklabs-io/cdnsd/internal/state"
 	"github.com/miekg/dns"
 )
+
+func TestStartReturnsShutdownHandle(t *testing.T) {
+	cfg := config.GetConfig()
+	oldDNS := cfg.Dns
+	oldTLS := cfg.Tls
+	cfg.Dns.ListenAddress = "127.0.0.1"
+	cfg.Dns.ListenPort = 0
+	cfg.Dns.ListenTlsPort = 0
+	cfg.Tls.CertFilePath = ""
+	cfg.Tls.KeyFilePath = ""
+	t.Cleanup(func() {
+		cfg.Dns = oldDNS
+		cfg.Tls = oldTLS
+	})
+
+	srv, err := Start()
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if srv == nil {
+		t.Fatal("Start() returned nil server")
+	}
+
+	select {
+	case err := <-srv.Errors():
+		t.Fatalf("unexpected listener error: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Close() after Shutdown() error = %v", err)
+	}
+}
+
+func TestStartDNSListenersIgnoresUnrelatedRuntimeError(t *testing.T) {
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {})
+	servers := []*dns.Server{
+		{
+			Addr:    "127.0.0.1:0",
+			Net:     "udp",
+			Handler: handler,
+		},
+		{
+			Addr:    "127.0.0.1:0",
+			Net:     "tcp",
+			Handler: handler,
+		},
+	}
+	srv := &Server{
+		servers: servers,
+		errCh:   make(chan error, len(servers)+1),
+	}
+	runtimeErr := errors.New("previous listener failed")
+	srv.errCh <- runtimeErr
+
+	if err := startDNSListeners(srv, servers); err != nil {
+		t.Fatalf("startDNSListeners() error = %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+
+	select {
+	case err := <-srv.Errors():
+		if !errors.Is(err, runtimeErr) {
+			t.Fatalf("unexpected runtime error = %v", err)
+		}
+	default:
+		t.Fatal("expected runtime error to remain pending")
+	}
+}
 
 func TestResolutionContextDefaults(t *testing.T) {
 	ctx := newResolutionContext()
@@ -457,6 +537,18 @@ func TestResolveNameserverAddressCycleDetection(t *testing.T) {
 	}
 	if ips != nil {
 		t.Error("expected nil result for cycle")
+	}
+}
+
+func TestResolveNameserverAddressWithoutState(t *testing.T) {
+	resolver := &Resolver{}
+	ctx := newResolutionContext()
+	ips, err := resolver.resolveNameserverAddress("ns.example.com.", ctx)
+	if err == nil {
+		t.Fatal("expected error without state or root hints")
+	}
+	if len(ips) != 0 {
+		t.Errorf("expected no IPs, got %v", ips)
 	}
 }
 

--- a/internal/indexer/handshake.go
+++ b/internal/indexer/handshake.go
@@ -29,18 +29,43 @@ type handshakeState struct {
 	hasLastBlock     bool
 }
 
-func (i *Indexer) startHandshake() error {
+func (i *Indexer) startHandshake(stopCh <-chan struct{}) error {
 	cfg := config.GetConfig()
 	if cfg.Indexer.HandshakeAddress == "" {
 		return nil
 	}
 	i.handshakeState.peerAddress = cfg.Indexer.HandshakeAddress
+	i.handshakeState.peerBackoffDelay = 0
 	// Start peer (re)connect loop
-	go i.handshakeReconnectPeer()
+	i.handshakeWg.Add(1)
+	go func() {
+		defer i.handshakeWg.Done()
+		i.handshakeReconnectPeer(stopCh)
+	}()
 	return nil
 }
 
-func (i *Indexer) handshakeConnectPeer() error {
+func (i *Indexer) handshakePeer() *handshake.Peer {
+	i.handshakeMu.Lock()
+	defer i.handshakeMu.Unlock()
+	return i.handshakeState.peer
+}
+
+func (i *Indexer) setHandshakePeer(peer *handshake.Peer) {
+	i.handshakeMu.Lock()
+	defer i.handshakeMu.Unlock()
+	i.handshakeState.peer = peer
+}
+
+func (i *Indexer) clearHandshakePeer(peer *handshake.Peer) {
+	i.handshakeMu.Lock()
+	defer i.handshakeMu.Unlock()
+	if peer == nil || i.handshakeState.peer == peer {
+		i.handshakeState.peer = nil
+	}
+}
+
+func (i *Indexer) handshakeConnectPeer(stopCh <-chan struct{}) error {
 	slog.Info(
 		"connecting to Handshake peer",
 		"address",
@@ -50,26 +75,36 @@ func (i *Indexer) handshakeConnectPeer() error {
 	if err != nil {
 		return err
 	}
-	i.handshakeState.peer = p
-	if err := i.handshakeState.peer.Connect(i.handshakeState.peerAddress); err != nil {
+	if err := p.Connect(i.handshakeState.peerAddress); err != nil {
+		i.clearHandshakePeer(p)
 		return err
+	}
+	i.setHandshakePeer(p)
+	select {
+	case <-stopCh:
+		_ = p.Close()
+		i.clearHandshakePeer(p)
+		return nil
+	default:
 	}
 	// Async error handler
 	go func() {
 		select {
-		case err := <-i.handshakeState.peer.ErrorChan():
+		case err := <-p.ErrorChan():
 			slog.Error(
 				"Handshake peer disconnected",
 				"error",
 				err,
 			)
-		case <-i.handshakeState.peer.DoneChan():
+		case <-p.DoneChan():
 			// Stop waiting on connection shutdown
 		}
 	}()
 	var locator [][32]byte = nil
 	cursorBlockHash, err := state.GetState().GetHandshakeCursor()
 	if err != nil {
+		_ = p.Close()
+		i.clearHandshakePeer(p)
 		return err
 	}
 	if cursorBlockHash != "" {
@@ -78,6 +113,8 @@ func (i *Indexer) handshakeConnectPeer() error {
 		)
 		hashBytes, err := hex.DecodeString(cursorBlockHash)
 		if err != nil {
+			_ = p.Close()
+			i.clearHandshakePeer(p)
 			return err
 		}
 		if len(hashBytes) != 32 {
@@ -85,6 +122,8 @@ func (i *Indexer) handshakeConnectPeer() error {
 			slog.Error(
 				fmt.Sprintf("bad Handshake cursor block hash: %x", hashBytes),
 			)
+			_ = p.Close()
+			i.clearHandshakePeer(p)
 			return errors.New("bad Handshake locator")
 		}
 		locator = [][32]byte{[32]byte(hashBytes)}
@@ -92,23 +131,39 @@ func (i *Indexer) handshakeConnectPeer() error {
 		i.handshakeState.hasLastBlock = true
 	}
 	// Start sync
-	if err := i.handshakeState.peer.Sync(locator, i.handshakeHandleSync); err != nil {
-		_ = i.handshakeState.peer.Close()
+	if err := p.Sync(locator, i.handshakeHandleSync); err != nil {
+		_ = p.Close()
+		i.clearHandshakePeer(p)
 		return err
 	}
 	return nil
 }
 
-func (i *Indexer) handshakeReconnectPeer() {
+func (i *Indexer) handshakeReconnectPeer(stopCh <-chan struct{}) {
 	var err error
 	// Try reconnecting to peer until we are successful
 	for {
-		err = i.handshakeConnectPeer()
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+		err = i.handshakeConnectPeer(stopCh)
 		if err == nil {
+			peer := i.handshakePeer()
+			if peer == nil {
+				continue
+			}
 			// Reset backoff delay
 			i.handshakeState.peerBackoffDelay = 0
 			// Wait for connection close
-			<-i.handshakeState.peer.DoneChan()
+			select {
+			case <-peer.DoneChan():
+				i.clearHandshakePeer(peer)
+			case <-stopCh:
+				_ = i.closeHandshakePeer()
+				return
+			}
 			continue
 		}
 		if i.handshakeState.peerBackoffDelay == 0 {
@@ -129,7 +184,18 @@ func (i *Indexer) handshakeReconnectPeer() {
 			"delay",
 			i.handshakeState.peerBackoffDelay.String(),
 		)
-		time.Sleep(i.handshakeState.peerBackoffDelay)
+		timer := time.NewTimer(i.handshakeState.peerBackoffDelay)
+		select {
+		case <-timer.C:
+		case <-stopCh:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return
+		}
 	}
 }
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
-	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blinklabs-io/adder/event"
@@ -62,6 +62,11 @@ type Indexer struct {
 	syncStatus     input_chainsync.ChainSyncStatus
 	watched        []watchedAddr
 	handshakeState handshakeState
+	handshakeMu    sync.Mutex
+	handshakeWg    sync.WaitGroup
+	errorCh        chan error
+	stopCh         chan struct{}
+	stopOnce       sync.Once
 }
 
 type watchedAddr struct {
@@ -74,21 +79,40 @@ type watchedAddr struct {
 // Singleton indexer instance
 var globalIndexer = &Indexer{
 	domains: make(map[string]Domain),
+	errorCh: make(chan error, 10),
+	stopCh:  make(chan struct{}),
 }
 
 func (i *Indexer) Start() error {
-	if err := i.startCardano(); err != nil {
+	if i.errorCh == nil {
+		i.errorCh = make(chan error, 10)
+	}
+	if i.stopCh == nil {
+		i.stopCh = make(chan struct{})
+		i.stopOnce = sync.Once{}
+	} else {
+		select {
+		case <-i.stopCh:
+			i.stopCh = make(chan struct{})
+			i.stopOnce = sync.Once{}
+		default:
+		}
+	}
+	stopCh := i.stopCh
+	if err := i.startCardano(stopCh); err != nil {
 		return err
 	}
-	if err := i.startHandshake(); err != nil {
+	if err := i.startHandshake(stopCh); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (i *Indexer) startCardano() error {
+func (i *Indexer) startCardano(stopCh <-chan struct{}) error {
 	// Build watched addresses from enabled profiles
 	cfg := config.GetConfig()
+	i.watched = nil
+	i.tipReached = false
 	for _, profile := range config.GetProfiles() {
 		if profile.ScriptAddress != "" {
 			// Add a static TLD mapping
@@ -230,23 +254,26 @@ func (i *Indexer) startCardano() error {
 	i.pipeline.AddOutput(output)
 	// Start pipeline
 	if err := i.pipeline.Start(); err != nil {
-		slog.Error(
-			fmt.Sprintf("failed to start pipeline: %s\n", err),
-		)
-		os.Exit(1)
+		return fmt.Errorf("failed to start pipeline: %w", err)
 	}
 	// Start error handler
-	go func() {
-		err, ok := <-i.pipeline.ErrorChan()
-		if ok {
-			slog.Error(
-				fmt.Sprintf("pipeline failed: %s\n", err),
-			)
-			os.Exit(1)
+	go func(errorCh <-chan error) {
+		for {
+			select {
+			case err, ok := <-errorCh:
+				if !ok {
+					return
+				}
+				if err != nil {
+					i.reportError(fmt.Errorf("pipeline failed: %w", err))
+				}
+			case <-stopCh:
+				return
+			}
 		}
-	}()
+	}(i.pipeline.ErrorChan())
 	// Schedule periodic catch-up sync log messages
-	i.scheduleSyncStatusLog()
+	i.scheduleSyncStatusLog(stopCh)
 	return nil
 }
 
@@ -496,11 +523,23 @@ func (i *Indexer) handleEventOutputDiscovery(
 	return nil
 }
 
-func (i *Indexer) scheduleSyncStatusLog() {
-	i.syncLogTimer = time.AfterFunc(syncStatusLogInterval, i.syncStatusLog)
+func (i *Indexer) scheduleSyncStatusLog(stopCh <-chan struct{}) {
+	select {
+	case <-stopCh:
+		return
+	default:
+	}
+	i.syncLogTimer = time.AfterFunc(syncStatusLogInterval, func() {
+		i.syncStatusLog(stopCh)
+	})
 }
 
-func (i *Indexer) syncStatusLog() {
+func (i *Indexer) syncStatusLog(stopCh <-chan struct{}) {
+	select {
+	case <-stopCh:
+		return
+	default:
+	}
 	slog.Info(
 		fmt.Sprintf(
 			"catch-up sync in progress: at %d.%s (current tip slot is %d)",
@@ -509,13 +548,75 @@ func (i *Indexer) syncStatusLog() {
 			i.syncStatus.TipSlotNumber,
 		),
 	)
-	i.scheduleSyncStatusLog()
+	i.scheduleSyncStatusLog(stopCh)
 }
 
 func (i *Indexer) LookupDomain(name string) *Domain {
 	if domain, ok := i.domains[name]; ok {
 		return &domain
 	}
+	return nil
+}
+
+// Errors returns asynchronous indexer failures.
+func (i *Indexer) Errors() <-chan error {
+	if i == nil {
+		return nil
+	}
+	return i.errorCh
+}
+
+func (i *Indexer) reportError(err error) {
+	select {
+	case i.errorCh <- err:
+	default:
+		slog.Error("indexer error", "error", err)
+	}
+}
+
+// Stop shuts down indexer background work.
+func (i *Indexer) Stop() error {
+	if i == nil {
+		return nil
+	}
+	var errs []error
+	i.stopOnce.Do(func() {
+		if i.stopCh != nil {
+			close(i.stopCh)
+		}
+		if i.syncLogTimer != nil {
+			i.syncLogTimer.Stop()
+			i.syncLogTimer = nil
+		}
+		if err := i.closeHandshakePeer(); err != nil {
+			errs = append(errs, err)
+		}
+		if i.pipeline != nil {
+			if err := i.pipeline.Stop(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		i.handshakeWg.Wait()
+	})
+	return errors.Join(errs...)
+}
+
+func (i *Indexer) closeHandshakePeer() error {
+	peer := i.handshakePeer()
+	if peer == nil {
+		return nil
+	}
+	select {
+	case <-peer.DoneChan():
+		i.clearHandshakePeer(peer)
+		return nil
+	default:
+	}
+	if err := peer.Close(); err != nil &&
+		!strings.Contains(err.Error(), "connection is not established") {
+		return err
+	}
+	i.clearHandshakePeer(peer)
 	return nil
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blinklabs-io/cdnsd/internal/config"
@@ -37,8 +38,11 @@ const (
 )
 
 type State struct {
-	db      *badger.DB
-	gcTimer *time.Ticker
+	db       *badger.DB
+	gcTimer  *time.Ticker
+	gcStopCh chan struct{}
+	gcDoneCh chan struct{}
+	mu       sync.Mutex
 }
 
 type DomainRecord struct {
@@ -66,18 +70,34 @@ func (s *State) Load() error {
 	if err != nil {
 		return err
 	}
+	s.mu.Lock()
 	s.db = db
+	s.mu.Unlock()
 	// Make sure existing DB matches current config options
 	if err := s.compareFingerprint(); err != nil {
+		_ = s.Close()
 		return err
 	}
 	// Run GC periodically for Badger DB
-	s.gcTimer = time.NewTicker(5 * time.Minute)
-	go func() {
-		for range s.gcTimer.C {
+	gcTimer := time.NewTicker(5 * time.Minute)
+	gcStopCh := make(chan struct{})
+	gcDoneCh := make(chan struct{})
+	s.mu.Lock()
+	s.gcTimer = gcTimer
+	s.gcStopCh = gcStopCh
+	s.gcDoneCh = gcDoneCh
+	s.mu.Unlock()
+	go func(db *badger.DB) {
+		defer close(gcDoneCh)
+		for {
+			select {
+			case <-gcTimer.C:
+			case <-gcStopCh:
+				return
+			}
 		again:
 			slog.Debug("database: running GC")
-			err := s.db.RunValueLogGC(0.5)
+			err := db.RunValueLogGC(0.5)
 			if err != nil {
 				// Log any actual errors
 				if !errors.Is(err, badger.ErrNoRewrite) {
@@ -93,7 +113,7 @@ func (s *State) Load() error {
 				goto again
 			}
 		}
-	}()
+	}(db)
 	return nil
 }
 
@@ -462,6 +482,34 @@ func (s *State) LookupHandshakeRecords(
 
 func GetState() *State {
 	return globalState
+}
+
+// Close stops background state maintenance and closes the Badger database.
+func (s *State) Close() error {
+	s.mu.Lock()
+	db := s.db
+	gcTimer := s.gcTimer
+	gcStopCh := s.gcStopCh
+	gcDoneCh := s.gcDoneCh
+	s.db = nil
+	s.gcTimer = nil
+	s.gcStopCh = nil
+	s.gcDoneCh = nil
+	if gcTimer != nil {
+		gcTimer.Stop()
+	}
+	if gcStopCh != nil {
+		close(gcStopCh)
+	}
+	s.mu.Unlock()
+
+	if gcDoneCh != nil {
+		<-gcDoneCh
+	}
+	if db == nil {
+		return nil
+	}
+	return db.Close()
 }
 
 // BadgerLogger is a wrapper type to give our logger the expected interface

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Blink Labs Software
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/cdnsd/internal/config"
+)
+
+func TestCloseStopsGCAndClosesDB(t *testing.T) {
+	cfg := config.GetConfig()
+	oldState := cfg.State
+	cfg.State.Directory = t.TempDir()
+	t.Cleanup(func() {
+		cfg.State = oldState
+	})
+
+	s := &State{}
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if s.db == nil {
+		t.Fatal("Load() did not open DB")
+	}
+	if s.gcTimer == nil {
+		t.Fatal("Load() did not start GC timer")
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if s.db != nil {
+		t.Fatal("Close() did not clear DB handle")
+	}
+	if s.gcTimer != nil {
+		t.Fatal("Close() did not clear GC timer")
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a graceful, signal-aware shutdown with clear error propagation and clean teardown across DNS, indexer, and HTTP debug/metrics. Prevents abrupt exits and resource leaks with a coordinated 15s shutdown.

- **New Features**
  - `cmd/cdnsd`: signal-aware `run()` with unified shutdown across `dns`, debug, metrics, `indexer`, and `state`; pre-bound HTTP listeners and runtime error fan-in from HTTP, `indexer.Errors()`, and `dns.Server.Errors()`.
  - `internal/dns`: `Start()` returns a `*Server` with `Shutdown(ctx)`, `Close()`, and `Errors()`; readiness gating with rollback; shared mux; TLS cert loaded once.
  - `internal/indexer`: `Errors()`, `Stop()`, and guarded Handshake peer lifecycle; pipeline errors and timers respect `stopCh`.
  - `internal/state`: `Close()` stops GC via stop/done channels and closes Badger safely.

- **Bug Fixes**
  - Replaced `os.Exit` with coordinated SIGINT/SIGTERM handling; async failures bubble up; errors joined and logged; state closes last.
  - Debug/metrics start on bound listeners; startup errors surfaced; `http.ErrServerClosed` ignored on shutdown.
  - DNS: listener failures reported instead of exiting; TLS load errors surfaced; readiness gating with rollback; resolver uses state when available, falls back to root hints, and fails clearly if neither is available.
  - Tests added for DNS shutdown handle and listener error resilience, plus state GC/DB closure.

<sup>Written for commit 18e194124d2bf1720dac91ba0ce854da093566c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cdnsd/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

