### PR TITLE
refactor: Resolver

### DIFF
--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -111,38 +111,40 @@ func (r *Resolver) resolveNameserverAddress(
 
 	var ips []net.IP
 
-	// Try local Cardano records first
-	aRecords, err := state.GetState().LookupRecords(
-		[]string{"A", "AAAA"},
-		nsName,
-	)
-	if err != nil {
-		return nil, err
-	}
-	for _, record := range aRecords {
-		if ip := net.ParseIP(record.Rhs); ip != nil {
-			ips = append(ips, ip)
+	if stateAvailable() {
+		// Try local Cardano records first
+		aRecords, err := state.GetState().LookupRecords(
+			[]string{"A", "AAAA"},
+			nsName,
+		)
+		if err != nil {
+			return nil, err
 		}
-	}
-	if len(ips) > 0 {
-		return ips, nil
-	}
+		for _, record := range aRecords {
+			if ip := net.ParseIP(record.Rhs); ip != nil {
+				ips = append(ips, ip)
+			}
+		}
+		if len(ips) > 0 {
+			return ips, nil
+		}
 
-	// Try local Handshake records
-	hsRecords, err := state.GetState().LookupHandshakeRecords(
-		[]string{"A", "AAAA"},
-		nsName,
-	)
-	if err != nil {
-		return nil, err
-	}
-	for _, record := range hsRecords {
-		if ip := net.ParseIP(record.Rhs); ip != nil {
-			ips = append(ips, ip)
+		// Try local Handshake records
+		hsRecords, err := state.GetState().LookupHandshakeRecords(
+			[]string{"A", "AAAA"},
+			nsName,
+		)
+		if err != nil {
+			return nil, err
 		}
-	}
-	if len(ips) > 0 {
-		return ips, nil
+		for _, record := range hsRecords {
+			if ip := net.ParseIP(record.Rhs); ip != nil {
+				ips = append(ips, ip)
+			}
+		}
+		if len(ips) > 0 {
+			return ips, nil
+		}
 	}
 
 	// Not found locally - resolve via upstream using root hints

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -37,6 +37,21 @@ var metricQueryTotal = promauto.NewCounter(prometheus.CounterOpts{
 	Help: "total DNS queries handled",
 })
 
+// Resolver handles DNS queries using configured root hints for
+// recursive resolution.
+type Resolver struct {
+	rootHints map[uint16]map[string][]dns.RR
+}
+
+// NewResolver creates a resolver from the provided config.
+func NewResolver(cfg *config.Config) (*Resolver, error) {
+	resolver := &Resolver{}
+	if err := resolver.loadRootHints(cfg); err != nil {
+		return nil, err
+	}
+	return resolver, nil
+}
+
 // resolutionContext tracks state during recursive DNS resolution
 // to prevent infinite loops and limit recursion depth.
 type resolutionContext struct {
@@ -78,7 +93,7 @@ func (c *resolutionContext) descend() *resolutionContext {
 // resolveNameserverAddress attempts to resolve A/AAAA records for a nameserver.
 // It first checks local storage (Cardano/Handshake), then falls back to
 // recursive resolution via upstream nameservers.
-func resolveNameserverAddress(
+func (r *Resolver) resolveNameserverAddress(
 	nsName string,
 	ctx *resolutionContext,
 ) ([]net.IP, error) {
@@ -139,12 +154,12 @@ func resolveNameserverAddress(
 	msg.RecursionDesired = true
 
 	// Start from root hints and resolve iteratively
-	rootNS := getRandomRootServer()
+	rootNS := r.getRandomRootServer()
 	if rootNS == "" {
 		return nil, errors.New("no root servers available")
 	}
 
-	resp, err := doQueryWithContext(msg, rootNS, true, childCtx)
+	resp, err := r.doQueryWithContext(msg, rootNS, true, childCtx)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"upstream resolution failed for %s: %w",
@@ -176,19 +191,17 @@ func resolveNameserverAddress(
 	return ips, nil
 }
 
-var rootHints map[uint16]map[string][]dns.RR
-
 // getRandomRootServer returns a random root server address from hints
-func getRandomRootServer() string {
-	if rootHints == nil {
+func (r *Resolver) getRandomRootServer() string {
+	if r == nil || r.rootHints == nil {
 		return ""
 	}
-	if rootHints[dns.TypeA] == nil {
+	if r.rootHints[dns.TypeA] == nil {
 		return ""
 	}
 	// Collect all A records
 	var servers []string
-	for _, rrs := range rootHints[dns.TypeA] {
+	for _, rrs := range r.rootHints[dns.TypeA] {
 		for _, rr := range rrs {
 			if a, ok := rr.(*dns.A); ok {
 				servers = append(servers, net.JoinHostPort(a.A.String(), "53"))
@@ -338,20 +351,21 @@ func Start() error {
 	slog.Info(
 		"starting DNS listener on " + listenAddr,
 	)
-	// Load root hints
-	if err := loadRootHints(cfg); err != nil {
+	resolver, err := NewResolver(cfg)
+	if err != nil {
 		return err
 	}
 	tlsConfig, err := loadConfiguredTLSConfig(cfg)
 	if err != nil {
 		return err
 	}
-	// Setup handler
-	dns.HandleFunc(".", handleQuery)
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", resolver.handleQuery)
 	// UDP listener
 	serverUdp := &dns.Server{
 		Addr:       listenAddr,
 		Net:        "udp",
+		Handler:    mux,
 		TsigSecret: nil,
 		ReusePort:  true,
 	}
@@ -360,6 +374,7 @@ func Start() error {
 	serverTcp := &dns.Server{
 		Addr:       listenAddr,
 		Net:        "tcp",
+		Handler:    mux,
 		TsigSecret: nil,
 		ReusePort:  true,
 	}
@@ -374,6 +389,7 @@ func Start() error {
 		serverTls := &dns.Server{
 			Addr:       listenTlsAddr,
 			Net:        "tcp-tls",
+			Handler:    mux,
 			TsigSecret: nil,
 			TLSConfig:  tlsConfig,
 			ReusePort:  false,
@@ -414,8 +430,8 @@ func loadTLSConfig(
 	}, nil
 }
 
-func loadRootHints(cfg *config.Config) error {
-	rootHints = make(map[uint16]map[string][]dns.RR)
+func (r *Resolver) loadRootHints(cfg *config.Config) error {
+	r.rootHints = make(map[uint16]map[string][]dns.RR)
 	for line := range strings.SplitSeq(cfg.Dns.RootHints, "\n") {
 		tmpRR, err := dns.NewRR(line)
 		if err != nil {
@@ -425,11 +441,11 @@ func loadRootHints(cfg *config.Config) error {
 			continue
 		}
 		rrType := tmpRR.Header().Rrtype
-		if _, ok := rootHints[rrType]; !ok {
-			rootHints[rrType] = make(map[string][]dns.RR)
+		if _, ok := r.rootHints[rrType]; !ok {
+			r.rootHints[rrType] = make(map[string][]dns.RR)
 		}
-		rootHints[rrType][tmpRR.Header().Name] = append(
-			rootHints[rrType][tmpRR.Header().Name],
+		r.rootHints[rrType][tmpRR.Header().Name] = append(
+			r.rootHints[rrType][tmpRR.Header().Name],
 			tmpRR,
 		)
 	}
@@ -445,12 +461,12 @@ func startListener(server *dns.Server) {
 	}
 }
 
-func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
-	if r == nil {
+func (r *Resolver) handleQuery(w dns.ResponseWriter, req *dns.Msg) {
+	if req == nil {
 		return
 	}
-	if len(r.Question) != 1 {
-		writeFormatError(w, r)
+	if len(req.Question) != 1 {
+		writeFormatError(w, req)
 		return
 	}
 
@@ -458,7 +474,7 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 	m := new(dns.Msg)
 
 	if cfg.Logging.QueryLog {
-		for _, q := range r.Question {
+		for _, q := range req.Question {
 			slog.Info(
 				fmt.Sprintf("query: name: %s, type: %s, class: %s",
 					q.Name,
@@ -472,8 +488,8 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 	metricQueryTotal.Inc()
 
 	// Check for known record from local storage
-	lookupRecordTypes := []uint16{r.Question[0].Qtype}
-	switch r.Question[0].Qtype {
+	lookupRecordTypes := []uint16{req.Question[0].Qtype}
+	switch req.Question[0].Qtype {
 	case dns.TypeA, dns.TypeAAAA:
 		// If the query is for A/AAAA, also try looking up matching CNAME records
 		lookupRecordTypes = append(lookupRecordTypes, dns.TypeCNAME)
@@ -482,7 +498,7 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 		// Try Cardano
 		records, err := state.GetState().LookupRecords(
 			[]string{dns.Type(lookupRecordType).String()},
-			strings.TrimSuffix(r.Question[0].Name, "."),
+			strings.TrimSuffix(req.Question[0].Name, "."),
 		)
 		if err != nil {
 			slog.Error(
@@ -494,7 +510,7 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 		if records == nil {
 			records, err = state.GetState().LookupHandshakeRecords(
 				[]string{dns.Type(lookupRecordType).String()},
-				strings.TrimSuffix(r.Question[0].Name, "."),
+				strings.TrimSuffix(req.Question[0].Name, "."),
 			)
 			if err != nil {
 				slog.Error(
@@ -505,7 +521,7 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 		}
 		if records != nil {
 			// Assemble response
-			m.SetReply(r)
+			m.SetReply(req)
 			m.Authoritative = true
 			for _, tmpRecord := range records {
 				tmpRR, err := stateRecordToDnsRR(tmpRecord)
@@ -533,10 +549,10 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 
 	// Handle SOA queries for blockchain TLDs when no explicit
 	// on-chain SOA was found
-	if r.Question[0].Qtype == dns.TypeSOA {
-		zone := findZoneForName(r.Question[0].Name)
+	if req.Question[0].Qtype == dns.TypeSOA {
+		zone := findZoneForName(req.Question[0].Name)
 		if zone != "" {
-			m.SetReply(r)
+			m.SetReply(req)
 			m.Authoritative = true
 			m.Answer = append(
 				m.Answer,
@@ -555,34 +571,34 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	// Check for any NS records for parent domains from local storage
-	nameserverDomain, nameservers, err := findNameserversForDomain(
-		r.Question[0].Name,
+	nameserverDomain, nameservers, err := r.findNameserversForDomain(
+		req.Question[0].Name,
 	)
 	if err != nil {
 		slog.Error(
 			fmt.Sprintf(
 				"failed to lookup nameservers for %s: %s",
-				r.Question[0].Name,
+				req.Question[0].Name,
 				err,
 			),
 		)
 	}
 	if nameservers != nil {
 		// Assemble response
-		m.SetReply(r)
+		m.SetReply(req)
 		if cfg.Dns.RecursionEnabled {
 			ctx := newResolutionContext()
 
 			// Try all nameservers with retry and failover
-			resp, err := queryMultipleNameservers(
-				r,
+			resp, err := r.queryMultipleNameservers(
+				req,
 				nameservers,
 				true,
 				ctx,
 			)
 			if err != nil {
 				// Send failure response
-				m.SetRcode(r, dns.RcodeServerFailure)
+				m.SetRcode(req, dns.RcodeServerFailure)
 				if err := w.WriteMsg(m); err != nil {
 					slog.Error(
 						fmt.Sprintf(
@@ -594,13 +610,13 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 				slog.Error(
 					fmt.Sprintf(
 						"recursive query failed: domain=%s, error=%s",
-						r.Question[0].Name,
+						req.Question[0].Name,
 						err,
 					),
 				)
 				return
 			}
-			copyResponse(r, resp, m)
+			copyResponse(req, resp, m)
 			// Send response
 			if err := w.WriteMsg(m); err != nil {
 				slog.Error(
@@ -651,9 +667,9 @@ func handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 
 	// Return NXDOMAIN if we have no information about the
 	// requested domain or any of its parents
-	m.SetRcode(r, dns.RcodeNameError)
+	m.SetRcode(req, dns.RcodeNameError)
 	// Include SOA in authority section for blockchain zones
-	zone := findZoneForName(r.Question[0].Name)
+	zone := findZoneForName(req.Question[0].Name)
 	if zone != "" {
 		m.Ns = append(m.Ns, generateSyntheticSOA(zone))
 	}
@@ -744,13 +760,13 @@ func queryWithRetry(
 
 // queryMultipleNameservers tries multiple nameservers until
 // one succeeds, using the default DNS port (53).
-func queryMultipleNameservers(
+func (r *Resolver) queryMultipleNameservers(
 	msg *dns.Msg,
 	nameservers map[string][]net.IP,
 	recursive bool,
 	ctx *resolutionContext,
 ) (*dns.Msg, error) {
-	return queryMultipleNameserversWithPort(
+	return r.queryMultipleNameserversWithPort(
 		msg,
 		nameservers,
 		recursive,
@@ -762,7 +778,7 @@ func queryMultipleNameservers(
 // queryMultipleNameserversWithPort tries multiple nameservers
 // until one succeeds. It shuffles the nameserver order and
 // uses retry logic for each server.
-func queryMultipleNameserversWithPort(
+func (r *Resolver) queryMultipleNameserversWithPort(
 	msg *dns.Msg,
 	nameservers map[string][]net.IP,
 	recursive bool,
@@ -878,7 +894,7 @@ func queryMultipleNameserversWithPort(
 		if recursive &&
 			!resp.Authoritative &&
 			len(resp.Ns) > 0 {
-			result, referralErr := handleReferral(
+			result, referralErr := r.handleReferral(
 				msg,
 				resp,
 				ctx,
@@ -924,7 +940,7 @@ func shuffleStrings(s []string) {
 
 // handleReferral processes a DNS referral response and
 // follows the delegation.
-func handleReferral(
+func (r *Resolver) handleReferral(
 	msg *dns.Msg,
 	resp *dns.Msg,
 	ctx *resolutionContext,
@@ -942,7 +958,7 @@ func handleReferral(
 	childCtx := ctx.descend()
 	for nsName, nsIPs := range nameservers {
 		if len(nsIPs) == 0 {
-			resolvedIPs, err := resolveNameserverAddress(
+			resolvedIPs, err := r.resolveNameserverAddress(
 				nsName,
 				childCtx,
 			)
@@ -960,7 +976,7 @@ func handleReferral(
 		}
 	}
 
-	return queryMultipleNameservers(
+	return r.queryMultipleNameservers(
 		msg,
 		nameservers,
 		true,
@@ -971,7 +987,7 @@ func handleReferral(
 // doQueryWithContext performs a DNS query with resolution
 // context for depth tracking. It uses retry logic and
 // configurable timeouts.
-func doQueryWithContext(
+func (r *Resolver) doQueryWithContext(
 	msg *dns.Msg,
 	address string,
 	recursive bool,
@@ -1001,7 +1017,7 @@ func doQueryWithContext(
 		"initial": {ip},
 	}
 
-	return queryMultipleNameserversWithPort(
+	return r.queryMultipleNameserversWithPort(
 		msg,
 		nameservers,
 		recursive,
@@ -1010,7 +1026,7 @@ func doQueryWithContext(
 	)
 }
 
-func findNameserversForDomain(
+func (r *Resolver) findNameserversForDomain(
 	recordName string,
 ) (string, map[string][]net.IP, error) {
 	// Split record name into labels and lookup each domain and parent until we get a hit
@@ -1058,7 +1074,7 @@ func findNameserversForDomain(
 				// If no local records, try to resolve via upstream
 				if len(nsIPs) == 0 {
 					ctx := newResolutionContext()
-					resolvedIPs, resolveErr := resolveNameserverAddress(
+					resolvedIPs, resolveErr := r.resolveNameserverAddress(
 						nsName,
 						ctx,
 					)
@@ -1111,7 +1127,7 @@ func findNameserversForDomain(
 				// If no local records, try to resolve via upstream
 				if len(nsIPs) == 0 {
 					ctx := newResolutionContext()
-					resolvedIPs, resolveErr := resolveNameserverAddress(
+					resolvedIPs, resolveErr := r.resolveNameserverAddress(
 						nsName,
 						ctx,
 					)
@@ -1135,16 +1151,16 @@ func findNameserversForDomain(
 	}
 	// Return root hints
 	ret := map[string][]net.IP{}
-	if rootHints != nil && rootHints[dns.TypeNS] != nil {
-		for _, tmpRecord := range rootHints[dns.TypeNS][`.`] {
+	if r != nil && r.rootHints != nil && r.rootHints[dns.TypeNS] != nil {
+		for _, tmpRecord := range r.rootHints[dns.TypeNS][`.`] {
 			nsRec := tmpRecord.(*dns.NS).Ns
-			if rootHints[dns.TypeA] != nil {
-				for _, aRecord := range rootHints[dns.TypeA][nsRec] {
+			if r.rootHints[dns.TypeA] != nil {
+				for _, aRecord := range r.rootHints[dns.TypeA][nsRec] {
 					ret[nsRec] = append(ret[nsRec], aRecord.(*dns.A).A)
 				}
 			}
-			if rootHints[dns.TypeAAAA] != nil {
-				for _, aaaaRecord := range rootHints[dns.TypeAAAA][nsRec] {
+			if r.rootHints[dns.TypeAAAA] != nil {
+				for _, aaaaRecord := range r.rootHints[dns.TypeAAAA][nsRec] {
 					ret[nsRec] = append(ret[nsRec], aaaaRecord.(*dns.AAAA).AAAA)
 				}
 			}

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -292,6 +292,7 @@ func (w *captureResponseWriter) TsigTimersOnly(bool) {}
 func (w *captureResponseWriter) Hijack() {}
 
 func TestHandleQueryMalformedQuestionCounts(t *testing.T) {
+	resolver := &Resolver{}
 	question := dns.Question{
 		Name:   "example.com.",
 		Qtype:  dns.TypeA,
@@ -333,7 +334,7 @@ func TestHandleQueryMalformedQuestionCounts(t *testing.T) {
 			}
 			w := &captureResponseWriter{}
 
-			handleQuery(w, req)
+			resolver.handleQuery(w, req)
 
 			if w.msg == nil {
 				t.Fatal("expected response")
@@ -365,6 +366,7 @@ func TestHandleQueryMalformedQuestionCounts(t *testing.T) {
 }
 
 func TestHandleQueryNilRequestDoesNotPanic(t *testing.T) {
+	resolver := &Resolver{}
 	w := &captureResponseWriter{}
 	defer func() {
 		if err := recover(); err != nil {
@@ -375,7 +377,39 @@ func TestHandleQueryNilRequestDoesNotPanic(t *testing.T) {
 		}
 	}()
 
-	handleQuery(w, nil)
+	resolver.handleQuery(w, nil)
+}
+
+func TestNewResolverLoadsRootHints(t *testing.T) {
+	cfg := *config.GetConfig()
+	cfg.Dns.RootHints = strings.Join(
+		[]string{
+			". 3600000 IN NS A.ROOT-TEST.",
+			"A.ROOT-TEST. 3600000 IN A 192.0.2.1",
+			"A.ROOT-TEST. 3600000 IN AAAA 2001:db8::1",
+		},
+		"\n",
+	)
+
+	resolver, err := NewResolver(&cfg)
+	if err != nil {
+		t.Fatalf("unexpected resolver error: %v", err)
+	}
+	if resolver.rootHints == nil {
+		t.Fatal("expected root hints to be initialized")
+	}
+	if len(resolver.rootHints[dns.TypeNS]["."]) != 1 {
+		t.Errorf("expected one root NS hint")
+	}
+	if len(resolver.rootHints[dns.TypeA]["A.ROOT-TEST."]) != 1 {
+		t.Errorf("expected one root A hint")
+	}
+	if len(resolver.rootHints[dns.TypeAAAA]["A.ROOT-TEST."]) != 1 {
+		t.Errorf("expected one root AAAA hint")
+	}
+	if rootNS := resolver.getRandomRootServer(); rootNS != "192.0.2.1:53" {
+		t.Errorf("expected root server 192.0.2.1:53, got %q", rootNS)
+	}
 }
 
 func TestResolveNameserverAddressFromLocal(t *testing.T) {
@@ -385,10 +419,11 @@ func TestResolveNameserverAddressFromLocal(t *testing.T) {
 		t.Skip("state database not loaded")
 	}
 
+	resolver := &Resolver{}
 	ctx := newResolutionContext()
 	// Resolving a nonexistent nameserver should return an error
 	// (no local records, upstream resolution will fail)
-	ips, err := resolveNameserverAddress("nonexistent.example.com.", ctx)
+	ips, err := resolver.resolveNameserverAddress("nonexistent.example.com.", ctx)
 	if err == nil {
 		t.Error("expected error for nonexistent nameserver")
 	}
@@ -398,10 +433,11 @@ func TestResolveNameserverAddressFromLocal(t *testing.T) {
 }
 
 func TestResolveNameserverAddressDepthLimit(t *testing.T) {
+	resolver := &Resolver{}
 	ctx := newResolutionContext()
 	ctx.depth = ctx.maxDepth // Already at max depth
 
-	ips, err := resolveNameserverAddress("any.example.com.", ctx)
+	ips, err := resolver.resolveNameserverAddress("any.example.com.", ctx)
 	if err == nil {
 		t.Error("expected error at max depth")
 	}
@@ -411,10 +447,11 @@ func TestResolveNameserverAddressDepthLimit(t *testing.T) {
 }
 
 func TestResolveNameserverAddressCycleDetection(t *testing.T) {
+	resolver := &Resolver{}
 	ctx := newResolutionContext()
 	ctx.markVisited("ns.example.com.") // Mark as already visited
 
-	ips, err := resolveNameserverAddress("ns.example.com.", ctx)
+	ips, err := resolver.resolveNameserverAddress("ns.example.com.", ctx)
 	if err == nil {
 		t.Error("expected error for cycle detection")
 	}
@@ -432,8 +469,9 @@ func TestDoQueryWithContextBasic(t *testing.T) {
 	msg := new(dns.Msg)
 	msg.SetQuestion("example.com.", dns.TypeA)
 
+	resolver := &Resolver{}
 	// This should work against a public resolver
-	resp, err := doQueryWithContext(msg, "8.8.8.8:53", false, ctx)
+	resp, err := resolver.doQueryWithContext(msg, "8.8.8.8:53", false, ctx)
 	if err != nil {
 		t.Skipf("network unavailable: %v", err)
 	}
@@ -459,9 +497,13 @@ func TestResolveNameserverAddressUpstream(t *testing.T) {
 		t.Skip("config not initialized")
 	}
 
+	resolver, err := NewResolver(cfg)
+	if err != nil {
+		t.Fatalf("unexpected resolver error: %v", err)
+	}
 	ctx := newResolutionContext()
 	// Try to resolve a well-known nameserver
-	ips, err := resolveNameserverAddress("a.root-servers.net.", ctx)
+	ips, err := resolver.resolveNameserverAddress("a.root-servers.net.", ctx)
 	if err != nil {
 		t.Logf("warning: upstream resolution failed: %v", err)
 		// Don't fail - network may not be available
@@ -485,7 +527,8 @@ func TestFindNameserversResolvesGlue(t *testing.T) {
 
 	// Test with a domain known to use external nameservers
 	// blinklabs.io is mentioned in the issue as an example
-	_, nsMap, err := findNameserversForDomain("blinklabs.io.")
+	resolver := &Resolver{}
+	_, nsMap, err := resolver.findNameserversForDomain("blinklabs.io.")
 	if err != nil {
 		t.Skipf("could not test: %v", err)
 	}
@@ -519,17 +562,25 @@ func TestThirdPartyDNSDelegation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.GetConfig()
+			if cfg == nil {
+				t.Skip("config not initialized")
+			}
+			resolver, err := NewResolver(cfg)
+			if err != nil {
+				t.Fatalf("unexpected resolver error: %v", err)
+			}
 			ctx := newResolutionContext()
 			msg := new(dns.Msg)
 			msg.SetQuestion(tc.domain, dns.TypeA)
 
 			// Start from root
-			rootNS := getRandomRootServer()
+			rootNS := resolver.getRandomRootServer()
 			if rootNS == "" {
 				t.Skip("no root servers configured")
 			}
 
-			resp, err := doQueryWithContext(msg, rootNS, true, ctx)
+			resp, err := resolver.doQueryWithContext(msg, rootNS, true, ctx)
 			if err != nil {
 				t.Skipf("network error: %v", err)
 			}
@@ -894,7 +945,8 @@ func TestQueryMultipleNameservers(t *testing.T) {
 	msg := new(dns.Msg)
 	msg.SetQuestion("example.com.", dns.TypeA)
 
-	resp, err := queryMultipleNameserversWithPort(
+	resolver := &Resolver{}
+	resp, err := resolver.queryMultipleNameserversWithPort(
 		msg,
 		nameservers,
 		false,
@@ -946,7 +998,8 @@ func TestQueryMultipleNameserversFailover(t *testing.T) {
 	msg := new(dns.Msg)
 	msg.SetQuestion("example.com.", dns.TypeA)
 
-	resp, err := queryMultipleNameserversWithPort(
+	resolver := &Resolver{}
+	resp, err := resolver.queryMultipleNameserversWithPort(
 		msg,
 		nameservers,
 		false,
@@ -968,7 +1021,8 @@ func TestQueryMultipleNameserversNoAddresses(t *testing.T) {
 
 	nameservers := map[string][]net.IP{}
 
-	_, err := queryMultipleNameservers(
+	resolver := &Resolver{}
+	_, err := resolver.queryMultipleNameservers(
 		msg,
 		nameservers,
 		false,
@@ -998,7 +1052,8 @@ func TestQueryTimeoutRespected(t *testing.T) {
 	msg.SetQuestion("example.com.", dns.TypeA)
 
 	start := time.Now()
-	_, err := doQueryWithContext(
+	resolver := &Resolver{}
+	_, err := resolver.doQueryWithContext(
 		msg,
 		"192.0.2.1:53",
 		false,
@@ -1075,7 +1130,8 @@ func TestServfailRetriedBeforeFailover(t *testing.T) {
 	msg := new(dns.Msg)
 	msg.SetQuestion("example.com.", dns.TypeA)
 
-	resp, err := doQueryWithContext(
+	resolver := &Resolver{}
+	resp, err := resolver.doQueryWithContext(
 		msg,
 		addr,
 		false,

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -596,6 +596,41 @@ func TestThirdPartyDNSDelegation(t *testing.T) {
 	}
 }
 
+func TestHandleReferralWithoutGlueSkipsUnloadedState(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.test.", dns.TypeA)
+
+	referral := new(dns.Msg)
+	referral.SetReply(msg)
+	referral.Ns = []dns.RR{
+		&dns.NS{
+			Hdr: dns.RR_Header{
+				Name:   "example.test.",
+				Rrtype: dns.TypeNS,
+				Class:  dns.ClassINET,
+				Ttl:    300,
+			},
+			Ns: "ns.external.test.",
+		},
+	}
+
+	resolver := &Resolver{}
+	ctx := newResolutionContext()
+	defer func() {
+		if err := recover(); err != nil {
+			t.Fatalf("handleReferral panicked: %v", err)
+		}
+	}()
+
+	resp, err := resolver.handleReferral(msg, referral, ctx)
+	if err == nil {
+		t.Fatal("expected referral resolution error with no root hints")
+	}
+	if resp != nil {
+		t.Fatal("expected nil response when referral resolution fails")
+	}
+}
+
 func TestGenerateSyntheticSOA(t *testing.T) {
 	soa := generateSyntheticSOA("ada.")
 	if soa == nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored DNS resolution into a per-instance `Resolver` and removed global state to improve isolation and testability across UDP/TCP/TLS. Also hardened error paths and tests to avoid panics and flaky network-dependent failures.

- **Refactors**
  - Introduced `Resolver` with per-instance `rootHints`; removed global `rootHints`; `NewResolver(cfg)` loads hints.
  - Converted core functions to methods: `handleQuery`, `resolveNameserverAddress`, `getRandomRootServer`, `doQueryWithContext`, `queryMultipleNameservers*`, `handleReferral`, `findNameserversForDomain`.
  - Updated startup to use a per-resolver `dns.NewServeMux` and pass it as `Handler` to UDP/TCP/TLS servers.
  - Hardened behavior and tests: guarded local lookups with `stateAvailable()`, added safety for nil requests and referral-without-glue/no-hints, and stabilized CI by skipping network-dependent tests when unavailable.

<sup>Written for commit a52ce150a0ff7f6253b137d3e9ca2cd2fc2791b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cdnsd/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS resolution reliability by isolating resolver state per server instance.
  * Fixed fallback handling for root DNS records so lookups are more consistent when resolving domains.
  * Updated DNS query processing across UDP, TCP, and TLS to use a shared request handler path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->