### PR TITLE
fix: state robustness

### DIFF
--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -371,8 +371,11 @@ func stateAvailable() bool {
 				available = false
 			}
 		}()
-		_, _ = state.GetState().
+		_, err := state.GetState().
 			LookupRecords([]string{"A"}, "__probe__")
+		if err != nil {
+			available = false
+		}
 	}()
 	return available
 }

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -331,7 +331,10 @@ func stateIsLoaded() bool {
 				loaded = false
 			}
 		}()
-		_, _ = s.LookupRecords([]string{"A"}, "test")
+		_, err := s.LookupRecords([]string{"A"}, "test")
+		if err != nil {
+			loaded = false
+		}
 	}()
 	return loaded
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -37,12 +37,15 @@ const (
 	handshakeRecordKeyPrefix   = "hs_r_"
 )
 
+// ErrStateNotLoaded is returned when an operation needs a loaded state database.
+var ErrStateNotLoaded = errors.New("state database is not loaded")
+
 type State struct {
-	db       *badger.DB
-	gcTimer  *time.Ticker
-	gcStopCh chan struct{}
-	gcDoneCh chan struct{}
-	mu       sync.Mutex
+	mu      sync.RWMutex
+	db      *badger.DB
+	gcTimer *time.Ticker
+	gcStop  chan struct{}
+	gcDone  chan struct{}
 }
 
 type DomainRecord struct {
@@ -70,61 +73,130 @@ func (s *State) Load() error {
 	if err != nil {
 		return err
 	}
-	s.mu.Lock()
-	s.db = db
-	s.mu.Unlock()
 	// Make sure existing DB matches current config options
-	if err := s.compareFingerprint(); err != nil {
-		_ = s.Close()
+	if err := compareFingerprint(db); err != nil {
+		_ = db.Close()
 		return err
 	}
 	// Run GC periodically for Badger DB
 	gcTimer := time.NewTicker(5 * time.Minute)
-	gcStopCh := make(chan struct{})
-	gcDoneCh := make(chan struct{})
+	gcStop := make(chan struct{})
+	gcDone := make(chan struct{})
 	s.mu.Lock()
+	if s.db != nil {
+		s.mu.Unlock()
+		gcTimer.Stop()
+		_ = db.Close()
+		return errors.New("state database is already loaded")
+	}
+	s.db = db
 	s.gcTimer = gcTimer
-	s.gcStopCh = gcStopCh
-	s.gcDoneCh = gcDoneCh
+	s.gcStop = gcStop
+	s.gcDone = gcDone
 	s.mu.Unlock()
-	go func(db *badger.DB) {
-		defer close(gcDoneCh)
-		for {
-			select {
-			case <-gcTimer.C:
-			case <-gcStopCh:
-				return
-			}
-		again:
-			slog.Debug("database: running GC")
-			err := db.RunValueLogGC(0.5)
-			if err != nil {
-				// Log any actual errors
-				if !errors.Is(err, badger.ErrNoRewrite) {
-					slog.Warn(
-						fmt.Sprintf(
-							"database: GC failure: %s",
-							err,
-						),
-					)
-				}
-			} else {
-				// Run it again if it just ran successfully
-				goto again
-			}
-		}
-	}(db)
+	go runGC(db, gcTimer, gcStop, gcDone)
 	return nil
 }
 
-func (s *State) compareFingerprint() error {
+func (s *State) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	db := s.db
+	gcTimer := s.gcTimer
+	gcStop := s.gcStop
+	gcDone := s.gcDone
+	s.db = nil
+	s.gcTimer = nil
+	s.gcStop = nil
+	s.gcDone = nil
+	if gcTimer != nil {
+		gcTimer.Stop()
+	}
+	if gcStop != nil {
+		close(gcStop)
+	}
+	s.mu.Unlock()
+	if gcDone != nil {
+		<-gcDone
+	}
+	if db == nil {
+		return nil
+	}
+	return db.Close()
+}
+
+func runGC(
+	db *badger.DB,
+	gcTimer *time.Ticker,
+	gcStop <-chan struct{},
+	gcDone chan<- struct{},
+) {
+	defer close(gcDone)
+	for {
+		select {
+		case <-gcStop:
+			return
+		case <-gcTimer.C:
+			for {
+				select {
+				case <-gcStop:
+					return
+				default:
+				}
+				slog.Debug("database: running GC")
+				err := db.RunValueLogGC(0.5)
+				if err != nil {
+					// Log any actual errors
+					if !errors.Is(err, badger.ErrNoRewrite) {
+						slog.Warn(
+							fmt.Sprintf(
+								"database: GC failure: %s",
+								err,
+							),
+						)
+					}
+					break
+				}
+				// Run it again if it just ran successfully
+			}
+		}
+	}
+}
+
+func (s *State) view(fn func(*badger.Txn) error) error {
+	if s == nil {
+		return ErrStateNotLoaded
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return ErrStateNotLoaded
+	}
+	return s.db.View(fn)
+}
+
+func (s *State) update(fn func(*badger.Txn) error) error {
+	if s == nil {
+		return ErrStateNotLoaded
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return ErrStateNotLoaded
+	}
+	return s.db.Update(fn)
+}
+
+func compareFingerprint(db *badger.DB) error {
 	cfg := config.GetConfig()
 	fingerprint := fmt.Sprintf(
 		"network=%s,network-magic=%d",
 		cfg.Indexer.Network,
 		cfg.Indexer.NetworkMagic,
 	)
-	err := s.db.Update(func(txn *badger.Txn) error {
+	err := db.Update(func(txn *badger.Txn) error {
 		item, err := txn.Get([]byte(fingerprintKey))
 		if err != nil {
 			if errors.Is(err, badger.ErrKeyNotFound) {
@@ -157,7 +229,7 @@ func (s *State) compareFingerprint() error {
 }
 
 func (s *State) UpdateCursor(slotNumber uint64, blockHash string) error {
-	err := s.db.Update(func(txn *badger.Txn) error {
+	err := s.update(func(txn *badger.Txn) error {
 		val := fmt.Sprintf("%d,%s", slotNumber, blockHash)
 		if err := txn.Set([]byte(chainsyncCursorKey), []byte(val)); err != nil {
 			return err
@@ -170,19 +242,18 @@ func (s *State) UpdateCursor(slotNumber uint64, blockHash string) error {
 func (s *State) GetCursor() (uint64, string, error) {
 	var slotNumber uint64
 	var blockHash string
-	err := s.db.View(func(txn *badger.Txn) error {
+	err := s.view(func(txn *badger.Txn) error {
 		item, err := txn.Get([]byte(chainsyncCursorKey))
 		if err != nil {
 			return err
 		}
 		err = item.Value(func(v []byte) error {
-			var err error
-			cursorParts := strings.Split(string(v), ",")
-			slotNumber, err = strconv.ParseUint(cursorParts[0], 10, 64)
+			tmpSlotNumber, tmpBlockHash, err := parseCursorValue(v)
 			if err != nil {
 				return err
 			}
-			blockHash = cursorParts[1]
+			slotNumber = tmpSlotNumber
+			blockHash = tmpBlockHash
 			return nil
 		})
 		if err != nil {
@@ -196,17 +267,53 @@ func (s *State) GetCursor() (uint64, string, error) {
 	return slotNumber, blockHash, err
 }
 
+func parseCursorValue(v []byte) (uint64, string, error) {
+	value := string(v)
+	cursorParts := strings.Split(value, ",")
+	if len(cursorParts) != 2 {
+		return 0, "", fmt.Errorf(
+			"malformed persisted chainsync cursor %q: expected slot,block_hash",
+			value,
+		)
+	}
+	if cursorParts[0] == "" {
+		return 0, "", fmt.Errorf(
+			"malformed persisted chainsync cursor %q: missing slot",
+			value,
+		)
+	}
+	slotNumber, err := strconv.ParseUint(cursorParts[0], 10, 64)
+	if err != nil {
+		return 0, "", fmt.Errorf(
+			"malformed persisted chainsync cursor %q: invalid slot %q: %w",
+			value,
+			cursorParts[0],
+			err,
+		)
+	}
+	if cursorParts[1] == "" {
+		return 0, "", fmt.Errorf(
+			"malformed persisted chainsync cursor %q: missing block hash",
+			value,
+		)
+	}
+	return slotNumber, cursorParts[1], nil
+}
+
 func (s *State) AddDiscoveredAddress(addr DiscoveredAddress) error {
-	tmpAddrs, err := s.GetDiscoveredAddresses()
-	if err != nil {
-		return err
-	}
-	tmpAddrs = append(tmpAddrs, addr)
-	tmpAddrsJson, err := json.Marshal(&tmpAddrs)
-	if err != nil {
-		return err
-	}
-	err = s.db.Update(func(txn *badger.Txn) error {
+	err := s.update(func(txn *badger.Txn) error {
+		tmpAddrs, err := getDiscoveredAddresses(txn)
+		if err != nil {
+			return err
+		}
+		tmpAddrs, changed := dedupeDiscoveredAddresses(tmpAddrs, addr)
+		if !changed {
+			return nil
+		}
+		tmpAddrsJson, err := json.Marshal(&tmpAddrs)
+		if err != nil {
+			return err
+		}
 		return txn.Set(
 			[]byte(discoveredAddrKey),
 			tmpAddrsJson,
@@ -220,25 +327,68 @@ func (s *State) AddDiscoveredAddress(addr DiscoveredAddress) error {
 
 func (s *State) GetDiscoveredAddresses() ([]DiscoveredAddress, error) {
 	var ret []DiscoveredAddress
-	err := s.db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get([]byte(discoveredAddrKey))
+	err := s.view(func(txn *badger.Txn) error {
+		tmpAddrs, err := getDiscoveredAddresses(txn)
 		if err != nil {
 			return err
 		}
-		err = item.Value(func(v []byte) error {
-			return json.Unmarshal(v, &ret)
-		})
-		if err != nil {
-			return err
-		}
+		ret = tmpAddrs
 		return nil
 	})
+	return ret, err
+}
+
+func getDiscoveredAddresses(txn *badger.Txn) ([]DiscoveredAddress, error) {
+	var ret []DiscoveredAddress
+	item, err := txn.Get([]byte(discoveredAddrKey))
 	if err != nil {
-		if !errors.Is(err, badger.ErrKeyNotFound) {
-			return ret, err
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil, nil
 		}
+		return nil, err
+	}
+	err = item.Value(func(v []byte) error {
+		return json.Unmarshal(v, &ret)
+	})
+	if err != nil {
+		return nil, err
 	}
 	return ret, nil
+}
+
+func dedupeDiscoveredAddresses(
+	addrs []DiscoveredAddress,
+	next DiscoveredAddress,
+) ([]DiscoveredAddress, bool) {
+	seen := make(map[string]struct{}, len(addrs)+1)
+	ret := make([]DiscoveredAddress, 0, len(addrs)+1)
+	nextKey := discoveredAddressDedupeKey(next)
+	foundNext := false
+	changed := false
+	for _, addr := range addrs {
+		key := discoveredAddressDedupeKey(addr)
+		if _, ok := seen[key]; ok {
+			changed = true
+			continue
+		}
+		seen[key] = struct{}{}
+		ret = append(ret, addr)
+		if key == nextKey {
+			foundNext = true
+		}
+	}
+	if !foundNext {
+		ret = append(ret, next)
+		changed = true
+	}
+	return ret, changed
+}
+
+func discoveredAddressDedupeKey(addr DiscoveredAddress) string {
+	return strings.Join(
+		[]string{addr.Address, addr.PolicyId, addr.TldName},
+		"\x00",
+	)
 }
 
 func (s *State) UpdateDomain(
@@ -259,7 +409,7 @@ func (s *State) updateDomain(
 	domainKeyPrefix string,
 	recordKeyPrefix string,
 ) error {
-	err := s.db.Update(func(txn *badger.Txn) error {
+	err := s.update(func(txn *badger.Txn) error {
 		// Add new records
 		recordKeys := make([]string, 0)
 		for recordIdx, record := range records {
@@ -347,7 +497,7 @@ func (s *State) lookupRecords(
 ) ([]DomainRecord, error) {
 	ret := []DomainRecord{}
 	recordName = strings.Trim(recordName, `.`)
-	err := s.db.View(func(txn *badger.Txn) error {
+	err := s.view(func(txn *badger.Txn) error {
 		for _, recordType := range recordTypes {
 			keyPrefix := fmt.Appendf(
 				nil,
@@ -392,7 +542,7 @@ func (s *State) lookupRecords(
 }
 
 func (s *State) UpdateHandshakeCursor(blockHash string) error {
-	err := s.db.Update(func(txn *badger.Txn) error {
+	err := s.update(func(txn *badger.Txn) error {
 		if err := txn.Set([]byte(handshakeCursorKey), []byte(blockHash)); err != nil {
 			return err
 		}
@@ -403,7 +553,7 @@ func (s *State) UpdateHandshakeCursor(blockHash string) error {
 
 func (s *State) GetHandshakeCursor() (string, error) {
 	var blockHash string
-	err := s.db.View(func(txn *badger.Txn) error {
+	err := s.view(func(txn *badger.Txn) error {
 		item, err := txn.Get([]byte(handshakeCursorKey))
 		if err != nil {
 			return err
@@ -424,7 +574,7 @@ func (s *State) GetHandshakeCursor() (string, error) {
 func (s *State) AddHandshakeName(name string) error {
 	nameHash := sha3.Sum256([]byte(name))
 	nameHashKey := fmt.Sprintf("%s%x", handshakeNameHashKeyPrefix, nameHash)
-	err := s.db.Update(func(txn *badger.Txn) error {
+	err := s.update(func(txn *badger.Txn) error {
 		return txn.Set(
 			[]byte(nameHashKey),
 			[]byte(name),
@@ -439,7 +589,7 @@ func (s *State) AddHandshakeName(name string) error {
 func (s *State) GetHandshakeNameByHash(nameHash []byte) (string, error) {
 	var ret string
 	nameHashKey := fmt.Sprintf("%s%x", handshakeNameHashKeyPrefix, nameHash)
-	err := s.db.View(func(txn *badger.Txn) error {
+	err := s.view(func(txn *badger.Txn) error {
 		item, err := txn.Get([]byte(nameHashKey))
 		if err != nil {
 			return err
@@ -482,34 +632,6 @@ func (s *State) LookupHandshakeRecords(
 
 func GetState() *State {
 	return globalState
-}
-
-// Close stops background state maintenance and closes the Badger database.
-func (s *State) Close() error {
-	s.mu.Lock()
-	db := s.db
-	gcTimer := s.gcTimer
-	gcStopCh := s.gcStopCh
-	gcDoneCh := s.gcDoneCh
-	s.db = nil
-	s.gcTimer = nil
-	s.gcStopCh = nil
-	s.gcDoneCh = nil
-	if gcTimer != nil {
-		gcTimer.Stop()
-	}
-	if gcStopCh != nil {
-		close(gcStopCh)
-	}
-	s.mu.Unlock()
-
-	if gcDoneCh != nil {
-		<-gcDoneCh
-	}
-	if db == nil {
-		return nil
-	}
-	return db.Close()
 }
 
 // BadgerLogger is a wrapper type to give our logger the expected interface

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -40,6 +40,9 @@ const (
 // ErrStateNotLoaded is returned when an operation needs a loaded state database.
 var ErrStateNotLoaded = errors.New("state database is not loaded")
 
+// ErrStateAlreadyLoaded is returned when loading an already loaded state database.
+var ErrStateAlreadyLoaded = errors.New("state database is already loaded")
+
 type State struct {
 	mu      sync.RWMutex
 	db      *badger.DB
@@ -64,6 +67,12 @@ type DiscoveredAddress struct {
 var globalState = &State{}
 
 func (s *State) Load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db != nil {
+		return ErrStateAlreadyLoaded
+	}
+
 	cfg := config.GetConfig()
 	badgerOpts := badger.DefaultOptions(cfg.State.Directory).
 		WithLogger(NewBadgerLogger()).
@@ -82,18 +91,10 @@ func (s *State) Load() error {
 	gcTimer := time.NewTicker(5 * time.Minute)
 	gcStop := make(chan struct{})
 	gcDone := make(chan struct{})
-	s.mu.Lock()
-	if s.db != nil {
-		s.mu.Unlock()
-		gcTimer.Stop()
-		_ = db.Close()
-		return errors.New("state database is already loaded")
-	}
 	s.db = db
 	s.gcTimer = gcTimer
 	s.gcStop = gcStop
 	s.gcDone = gcDone
-	s.mu.Unlock()
 	go runGC(db, gcTimer, gcStop, gcDone)
 	return nil
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -7,40 +7,272 @@
 package state
 
 import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/cdnsd/internal/config"
+	"github.com/dgraph-io/badger/v4"
 )
 
-func TestCloseStopsGCAndClosesDB(t *testing.T) {
+func newLoadedTestState(t *testing.T) *State {
+	t.Helper()
 	cfg := config.GetConfig()
-	oldState := cfg.State
+	oldStateDir := cfg.State.Directory
+	oldNetwork := cfg.Indexer.Network
+	oldNetworkMagic := cfg.Indexer.NetworkMagic
 	cfg.State.Directory = t.TempDir()
+	cfg.Indexer.Network = "state-test"
+	cfg.Indexer.NetworkMagic = 42
 	t.Cleanup(func() {
-		cfg.State = oldState
+		cfg.State.Directory = oldStateDir
+		cfg.Indexer.Network = oldNetwork
+		cfg.Indexer.NetworkMagic = oldNetworkMagic
 	})
-
 	s := &State{}
 	if err := s.Load(); err != nil {
-		t.Fatalf("Load() error = %v", err)
+		t.Fatalf("failed to load state: %v", err)
 	}
-	if s.db == nil {
-		t.Fatal("Load() did not open DB")
-	}
-	if s.gcTimer == nil {
-		t.Fatal("Load() did not start GC timer")
-	}
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Errorf("failed to close state: %v", err)
+		}
+	})
+	return s
+}
 
+func setRawCursor(t *testing.T, s *State, value string) {
+	t.Helper()
+	if err := s.update(func(txn *badger.Txn) error {
+		return txn.Set([]byte(chainsyncCursorKey), []byte(value))
+	}); err != nil {
+		t.Fatalf("failed to set raw cursor: %v", err)
+	}
+}
+
+func setRawDiscoveredAddresses(
+	t *testing.T,
+	s *State,
+	addrs []DiscoveredAddress,
+) {
+	t.Helper()
+	payload, err := json.Marshal(addrs)
+	if err != nil {
+		t.Fatalf("failed to marshal discovered addresses: %v", err)
+	}
+	if err := s.update(func(txn *badger.Txn) error {
+		return txn.Set([]byte(discoveredAddrKey), payload)
+	}); err != nil {
+		t.Fatalf("failed to set discovered addresses: %v", err)
+	}
+}
+
+func TestCloseStopsTickerAndClosesBadger(t *testing.T) {
+	s := newLoadedTestState(t)
+	if s.gcTimer == nil {
+		t.Fatal("expected GC ticker to be initialized")
+	}
+	if err := s.UpdateCursor(7, "block-hash"); err != nil {
+		t.Fatalf("failed to update cursor: %v", err)
+	}
 	if err := s.Close(); err != nil {
-		t.Fatalf("Close() error = %v", err)
+		t.Fatalf("failed to close state: %v", err)
 	}
 	if s.db != nil {
-		t.Fatal("Close() did not clear DB handle")
+		t.Fatal("expected db to be cleared after close")
 	}
 	if s.gcTimer != nil {
-		t.Fatal("Close() did not clear GC timer")
+		t.Fatal("expected GC ticker to be cleared after close")
 	}
-	if err := s.Close(); err != nil {
-		t.Fatalf("second Close() error = %v", err)
+	if _, _, err := s.GetCursor(); !errors.Is(err, ErrStateNotLoaded) {
+		t.Fatalf("expected ErrStateNotLoaded after close, got %v", err)
+	}
+	if err := s.Load(); err != nil {
+		t.Fatalf("expected state to reload after close: %v", err)
+	}
+	slot, hash, err := s.GetCursor()
+	if err != nil {
+		t.Fatalf("failed to get cursor after reload: %v", err)
+	}
+	if slot != 7 || hash != "block-hash" {
+		t.Fatalf("unexpected cursor after reload: slot=%d hash=%q", slot, hash)
+	}
+}
+
+func TestGetCursorReturnsErrorForMalformedPersistedValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "missing separator", value: "123"},
+		{name: "missing slot", value: ",block-hash"},
+		{name: "invalid slot", value: "not-a-slot,block-hash"},
+		{name: "missing hash", value: "123,"},
+		{name: "extra separator", value: "123,block-hash,extra"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := newLoadedTestState(t)
+			setRawCursor(t, s, test.value)
+			_, _, err := s.GetCursor()
+			if err == nil {
+				t.Fatal("expected malformed cursor error")
+			}
+			if !strings.Contains(
+				err.Error(),
+				"malformed persisted chainsync cursor",
+			) {
+				t.Fatalf("expected clear malformed cursor error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAddDiscoveredAddressDedupeAddressPolicyTLD(t *testing.T) {
+	s := newLoadedTestState(t)
+	addr := DiscoveredAddress{
+		Address:  "addr1",
+		PolicyId: "policy1",
+		TldName:  "alpha",
+	}
+	sameAddressDifferentTLD := DiscoveredAddress{
+		Address:  "addr1",
+		PolicyId: "policy1",
+		TldName:  "beta",
+	}
+	for _, tmpAddr := range []DiscoveredAddress{
+		addr,
+		addr,
+		sameAddressDifferentTLD,
+	} {
+		if err := s.AddDiscoveredAddress(tmpAddr); err != nil {
+			t.Fatalf("failed to add discovered address: %v", err)
+		}
+	}
+	got, err := s.GetDiscoveredAddresses()
+	if err != nil {
+		t.Fatalf("failed to get discovered addresses: %v", err)
+	}
+	expected := []DiscoveredAddress{addr, sameAddressDifferentTLD}
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("unexpected discovered addresses: got %#v expected %#v", got, expected)
+	}
+
+	newAddr := DiscoveredAddress{
+		Address:  "addr2",
+		PolicyId: "policy2",
+		TldName:  "gamma",
+	}
+	setRawDiscoveredAddresses(
+		t,
+		s,
+		[]DiscoveredAddress{addr, addr, sameAddressDifferentTLD},
+	)
+	if err := s.AddDiscoveredAddress(newAddr); err != nil {
+		t.Fatalf("failed to add discovered address to duplicated set: %v", err)
+	}
+	got, err = s.GetDiscoveredAddresses()
+	if err != nil {
+		t.Fatalf("failed to get discovered addresses: %v", err)
+	}
+	expected = []DiscoveredAddress{addr, sameAddressDifferentTLD, newAddr}
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("unexpected deduped addresses: got %#v expected %#v", got, expected)
+	}
+}
+
+func TestStateMethodsReturnNotLoadedError(t *testing.T) {
+	s := &State{}
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "UpdateCursor",
+			fn: func() error {
+				return s.UpdateCursor(1, "block-hash")
+			},
+		},
+		{
+			name: "GetCursor",
+			fn: func() error {
+				_, _, err := s.GetCursor()
+				return err
+			},
+		},
+		{
+			name: "AddDiscoveredAddress",
+			fn: func() error {
+				return s.AddDiscoveredAddress(DiscoveredAddress{})
+			},
+		},
+		{
+			name: "GetDiscoveredAddresses",
+			fn: func() error {
+				_, err := s.GetDiscoveredAddresses()
+				return err
+			},
+		},
+		{
+			name: "UpdateDomain",
+			fn: func() error {
+				return s.UpdateDomain("example", nil)
+			},
+		},
+		{
+			name: "LookupRecords",
+			fn: func() error {
+				_, err := s.LookupRecords([]string{"A"}, "example")
+				return err
+			},
+		},
+		{
+			name: "UpdateHandshakeCursor",
+			fn: func() error {
+				return s.UpdateHandshakeCursor("block-hash")
+			},
+		},
+		{
+			name: "GetHandshakeCursor",
+			fn: func() error {
+				_, err := s.GetHandshakeCursor()
+				return err
+			},
+		},
+		{
+			name: "AddHandshakeName",
+			fn: func() error {
+				return s.AddHandshakeName("example")
+			},
+		},
+		{
+			name: "GetHandshakeNameByHash",
+			fn: func() error {
+				_, err := s.GetHandshakeNameByHash([]byte("hash"))
+				return err
+			},
+		},
+		{
+			name: "UpdateHandshakeDomain",
+			fn: func() error {
+				return s.UpdateHandshakeDomain("example", nil)
+			},
+		},
+		{
+			name: "LookupHandshakeRecords",
+			fn: func() error {
+				_, err := s.LookupHandshakeRecords([]string{"A"}, "example")
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.fn(); !errors.Is(err, ErrStateNotLoaded) {
+				t.Fatalf("expected ErrStateNotLoaded, got %v", err)
+			}
+		})
 	}
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -101,6 +101,25 @@ func TestCloseStopsTickerAndClosesBadger(t *testing.T) {
 	}
 }
 
+func TestLoadReturnsAlreadyLoadedForLoadedState(t *testing.T) {
+	s := newLoadedTestState(t)
+	if err := s.UpdateCursor(11, "block-hash"); err != nil {
+		t.Fatalf("failed to update cursor: %v", err)
+	}
+
+	if err := s.Load(); !errors.Is(err, ErrStateAlreadyLoaded) {
+		t.Fatalf("expected ErrStateAlreadyLoaded, got %v", err)
+	}
+
+	slot, hash, err := s.GetCursor()
+	if err != nil {
+		t.Fatalf("failed to get cursor after second load: %v", err)
+	}
+	if slot != 11 || hash != "block-hash" {
+		t.Fatalf("unexpected cursor after second load: slot=%d hash=%q", slot, hash)
+	}
+}
+
 func TestGetCursorReturnsErrorForMalformedPersistedValues(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened `internal/state` to prevent use-before-load, avoid double-loads, ensure clean shutdown, and validate persisted data. `internal/dns` now treats state lookup errors as unavailable.

- **Bug Fixes**
  - Return `ErrStateNotLoaded` when the DB isn’t loaded and `ErrStateAlreadyLoaded` on repeated loads; DNS probes now mark unavailable on lookup errors.
  - Strictly validate chainsync cursor; reject malformed values with clear errors.
  - Deduplicate discovered addresses by address+policyId+tldName and skip no-op writes.
  - Ensure GC goroutine stops on close, wait for shutdown, and allow safe reload.

- **Refactors**
  - Added RW locking and `view`/`update` helpers for safe Badger transactions.
  - Extracted `runGC`, `compareFingerprint`, and cursor parsing helpers.
  - Expanded tests for close/reload, malformed cursor, dedupe, not-loaded, and already-loaded paths.

<sup>Written for commit bd395cf2de6b2681d7ecfb27afc4adebb4522552. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cdnsd/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

