### PR TITLE
feat: DNSSEC

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Resolver for Cardano-based second-level domains on Handshake top-level domains
 - **Multi-protocol DNS service:**
   - Standard DNS over UDP and TCP
   - DNS over TLS (when enabled)
+- **DNSSEC-aware recursive resolution:**
+  - Validates signed answers and authenticated denial of existence
+  - Supports IANA and blockchain-authenticated roots
 - **Real-time monitoring:**
   - Prometheus metrics endpoint
   - Optional request-level query logging
@@ -40,6 +43,9 @@ Resolver for Cardano-based second-level domains on Handshake top-level domains
 | `dns.recursionEnabled`  | bool         | `DNS_RECURSION`                   | Allow recursive DNS lookups |
 | `dns.rootHints`         | string       | `DNS_ROOT_HINTS`                  | DNS root hints (PEM string) |
 | `dns.rootHintsFile`     | string       | `DNS_ROOT_HINTS_FILE`             | File path to DNS root hints |
+| `dns.dnssec.enabled`    | bool         | `DNSSEC_ENABLED`                  | Validate recursive DNSSEC chains (default: false) |
+| `dns.dnssec.trustAnchors` | string     | `DNSSEC_TRUST_ANCHORS`            | DS or DNSKEY trust anchors in zone-file format |
+| `dns.dnssec.trustAnchorsFile` | string | `DNSSEC_TRUST_ANCHORS_FILE`       | File containing DS or DNSKEY trust anchors |
 | `debug.address`         | string       | `DEBUG_ADDRESS`                   | Address for debug HTTP server (default: localhost) |
 | `debug.port`            | uint         | `DEBUG_PORT`                      | Port for debug HTTP server |
 | `indexer.network`       | string       | `INDEXER_NETWORK`                 | Cardano network name (e.g. preprod, mainnet) |
@@ -68,8 +74,12 @@ dns:
   address: "0.0.0.0"
   port: 8053
   tlsPort: 8853
-  recursionEnabled: false
+  recursionEnabled: true
   rootHintsFile: "/etc/cdnsd/named.root"
+  dnssec:
+    enabled: true
+    # Optional: replaces the bundled IANA root anchors.
+    trustAnchorsFile: "/etc/cdnsd/root.keys"
 debug:
   address: "127.0.0.1"
   port: 6060
@@ -90,6 +100,24 @@ tls:
 profiles:
   - "cardano-preprod-testing"
 ```
+
+### DNSSEC and multiple roots
+
+DNSSEC validation is opt-in. When enabled, cdnsd requests DNSSEC records
+from authoritative servers, validates each signed delegation, returns the
+Authenticated Data (`AD`) bit for secure answers, and returns `SERVFAIL`
+for bogus data. Securely proven unsigned delegations continue to resolve
+without the `AD` bit.
+
+The bundled trust-anchor set contains the IANA KSK-2017 and KSK-2024
+anchors. Supplying `trustAnchors` or `trustAnchorsFile` replaces that set.
+Each non-comment line must be a complete `DS` or `DNSKEY` record, and
+anchors for multiple zones may be listed together.
+
+Cardano and Handshake records do not need to descend from the ICANN root.
+When an on-chain delegation contains a `DS` record, cdnsd uses that record
+as the trust anchor for the delegated zone. This creates a separate,
+blockchain-authenticated DNSSEC island for each applicable root.
 
 ### Profiles
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,16 +33,23 @@ type LoggingConfig struct {
 }
 
 type DnsConfig struct {
-	ListenAddress    string    `yaml:"address"          envconfig:"DNS_LISTEN_ADDRESS"`
-	ListenPort       uint      `yaml:"port"             envconfig:"DNS_LISTEN_PORT"`
-	ListenTlsPort    uint      `yaml:"tlsPort"          envconfig:"DNS_LISTEN_TLS_PORT"`
-	RecursionEnabled bool      `yaml:"recursionEnabled" envconfig:"DNS_RECURSION"`
-	RootHints        string    `yaml:"rootHints"        envconfig:"DNS_ROOT_HINTS"`
-	RootHintsFile    string    `yaml:"rootHintsFile"    envconfig:"DNS_ROOT_HINTS_FILE"`
-	RetryCount       int       `yaml:"retryCount"       envconfig:"DNS_RETRY_COUNT"`
-	RetryDelayMs     int       `yaml:"retryDelayMs"     envconfig:"DNS_RETRY_DELAY_MS"`
-	QueryTimeoutMs   int       `yaml:"queryTimeoutMs"   envconfig:"DNS_QUERY_TIMEOUT_MS"`
-	SOA              SOAConfig `yaml:"soa"`
+	ListenAddress    string       `yaml:"address"          envconfig:"DNS_LISTEN_ADDRESS"`
+	ListenPort       uint         `yaml:"port"             envconfig:"DNS_LISTEN_PORT"`
+	ListenTlsPort    uint         `yaml:"tlsPort"          envconfig:"DNS_LISTEN_TLS_PORT"`
+	RecursionEnabled bool         `yaml:"recursionEnabled" envconfig:"DNS_RECURSION"`
+	RootHints        string       `yaml:"rootHints"        envconfig:"DNS_ROOT_HINTS"`
+	RootHintsFile    string       `yaml:"rootHintsFile"    envconfig:"DNS_ROOT_HINTS_FILE"`
+	RetryCount       int          `yaml:"retryCount"       envconfig:"DNS_RETRY_COUNT"`
+	RetryDelayMs     int          `yaml:"retryDelayMs"     envconfig:"DNS_RETRY_DELAY_MS"`
+	QueryTimeoutMs   int          `yaml:"queryTimeoutMs"   envconfig:"DNS_QUERY_TIMEOUT_MS"`
+	DNSSEC           DNSSECConfig `yaml:"dnssec"`
+	SOA              SOAConfig    `yaml:"soa"`
+}
+
+type DNSSECConfig struct {
+	Enabled          bool   `yaml:"enabled"          envconfig:"DNSSEC_ENABLED"`
+	TrustAnchors     string `yaml:"trustAnchors"     envconfig:"DNSSEC_TRUST_ANCHORS"`
+	TrustAnchorsFile string `yaml:"trustAnchorsFile" envconfig:"DNSSEC_TRUST_ANCHORS_FILE"`
 }
 
 type DebugConfig struct {
@@ -87,6 +94,9 @@ type TlsConfig struct {
 //go:embed named.root
 var defaultRootHints []byte
 
+//go:embed root.keys
+var defaultTrustAnchors []byte
+
 // Singleton config instance with default values
 var globalConfig = &Config{
 	Logging: LoggingConfig{
@@ -100,6 +110,9 @@ var globalConfig = &Config{
 		RetryCount:     3,
 		RetryDelayMs:   100,
 		QueryTimeoutMs: 5000,
+		DNSSEC: DNSSECConfig{
+			TrustAnchors: string(defaultTrustAnchors),
+		},
 		SOA: SOAConfig{
 			Mname:   "ns1.cdnsd.localhost.",
 			Rname:   "hostmaster.cdnsd.localhost.",
@@ -211,6 +224,21 @@ func Load(configFile string) (*Config, error) {
 			return nil, err
 		}
 		globalConfig.Dns.RootHints = string(hintsContent)
+	}
+	// Load DNSSEC trust anchors. The file contains ordinary DS or
+	// DNSKEY records in zone-file presentation format.
+	if globalConfig.Dns.DNSSEC.TrustAnchorsFile != "" {
+		anchorsContent, err := os.ReadFile(
+			globalConfig.Dns.DNSSEC.TrustAnchorsFile,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"read DNSSEC trust anchors file %q: %w",
+				globalConfig.Dns.DNSSEC.TrustAnchorsFile,
+				err,
+			)
+		}
+		globalConfig.Dns.DNSSEC.TrustAnchors = string(anchorsContent)
 	}
 	return globalConfig, nil
 }

--- a/internal/config/root.keys
+++ b/internal/config/root.keys
@@ -1,0 +1,6 @@
+; IANA DNS root trust anchors. Keep both KSK-2017 and KSK-2024
+; through the scheduled October 2026 rollover.
+; Before each release, monitor https://data.iana.org/root-anchors/ for
+; changes and refresh this file before a published anchor is revoked.
+. 3600 IN DS 20326 8 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D
+. 3600 IN DS 38696 8 2 683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -41,13 +41,20 @@ var metricQueryTotal = promauto.NewCounter(prometheus.CounterOpts{
 // Resolver handles DNS queries using configured root hints for
 // recursive resolution.
 type Resolver struct {
-	rootHints map[uint16]map[string][]dns.RR
+	rootHints     map[uint16]map[string][]dns.RR
+	dnssecEnabled bool
+	trustAnchors  map[string][]dns.RR
 }
 
 // NewResolver creates a resolver from the provided config.
 func NewResolver(cfg *config.Config) (*Resolver, error) {
-	resolver := &Resolver{}
+	resolver := &Resolver{
+		dnssecEnabled: cfg.Dns.DNSSEC.Enabled,
+	}
 	if err := resolver.loadRootHints(cfg); err != nil {
+		return nil, err
+	}
+	if err := resolver.loadTrustAnchors(cfg); err != nil {
 		return nil, err
 	}
 	return resolver, nil
@@ -56,16 +63,19 @@ func NewResolver(cfg *config.Config) (*Resolver, error) {
 // resolutionContext tracks state during recursive DNS resolution
 // to prevent infinite loops and limit recursion depth.
 type resolutionContext struct {
-	depth    int
-	maxDepth int
-	visited  map[string]bool
+	depth      int
+	maxDepth   int
+	visited    map[string]bool
+	validation *dnssecValidation
+	requestCtx context.Context
 }
 
 func newResolutionContext() *resolutionContext {
 	return &resolutionContext{
-		depth:    0,
-		maxDepth: 10,
-		visited:  make(map[string]bool),
+		depth:      0,
+		maxDepth:   10,
+		visited:    make(map[string]bool),
+		requestCtx: context.Background(),
 	}
 }
 
@@ -85,9 +95,11 @@ func (c *resolutionContext) descend() *resolutionContext {
 	newVisited := make(map[string]bool, len(c.visited))
 	maps.Copy(newVisited, c.visited)
 	return &resolutionContext{
-		depth:    c.depth + 1,
-		maxDepth: c.maxDepth,
-		visited:  newVisited,
+		depth:      c.depth + 1,
+		maxDepth:   c.maxDepth,
+		visited:    newVisited,
+		validation: c.validation,
+		requestCtx: c.requestCtx,
 	}
 }
 
@@ -150,6 +162,13 @@ func (r *Resolver) resolveNameserverAddress(
 
 	// Not found locally - resolve via upstream using root hints
 	childCtx := ctx.descend()
+	if r.dnssecEnabled {
+		validation, err := r.dnssecContextForZone(".", false)
+		if err != nil {
+			return nil, err
+		}
+		childCtx.validation = validation
+	}
 
 	// Build a DNS query for the nameserver's A record
 	msg := new(dns.Msg)
@@ -597,6 +616,7 @@ func (r *Resolver) handleQuery(w dns.ResponseWriter, req *dns.Msg) {
 		lookupRecordTypes = append(lookupRecordTypes, dns.TypeCNAME)
 	}
 	for _, lookupRecordType := range lookupRecordTypes {
+		fromHandshake := false
 		// Try Cardano
 		records, err := state.GetState().LookupRecords(
 			[]string{dns.Type(lookupRecordType).String()},
@@ -620,6 +640,7 @@ func (r *Resolver) handleQuery(w dns.ResponseWriter, req *dns.Msg) {
 				)
 				return
 			}
+			fromHandshake = records != nil
 		}
 		if records != nil {
 			// Assemble response
@@ -637,6 +658,27 @@ func (r *Resolver) handleQuery(w dns.ResponseWriter, req *dns.Msg) {
 					return
 				}
 				m.Answer = append(m.Answer, tmpRR)
+			}
+			if wantsDNSSEC(req) &&
+				req.Question[0].Qtype != dns.TypeRRSIG {
+				signatures, err := lookupLocalSignatures(
+					strings.TrimSuffix(
+						req.Question[0].Name,
+						".",
+					),
+					fromHandshake,
+					m.Answer,
+				)
+				if err != nil {
+					slog.Error(
+						fmt.Sprintf(
+							"failed to lookup DNSSEC signatures: %s",
+							err,
+						),
+					)
+					return
+				}
+				m.Answer = append(m.Answer, signatures...)
 			}
 			// Send response
 			if err := w.WriteMsg(m); err != nil {
@@ -656,9 +698,10 @@ func (r *Resolver) handleQuery(w dns.ResponseWriter, req *dns.Msg) {
 		if zone != "" {
 			m.SetReply(req)
 			m.Authoritative = true
+			soa := generateSyntheticSOA(zone)
 			m.Answer = append(
 				m.Answer,
-				generateSyntheticSOA(zone),
+				soa,
 			)
 			if err := w.WriteMsg(m); err != nil {
 				slog.Error(
@@ -685,11 +728,37 @@ func (r *Resolver) handleQuery(w dns.ResponseWriter, req *dns.Msg) {
 			),
 		)
 	}
-	if nameservers != nil {
+	if len(nameservers) > 0 {
 		// Assemble response
 		m.SetReply(req)
 		if cfg.Dns.RecursionEnabled {
 			ctx := newResolutionContext()
+			if r.dnssecEnabled && !req.CheckingDisabled {
+				validation, validationErr := r.dnssecContextForZone(
+					nameserverDomain,
+					nameserverDomain != ".",
+				)
+				if validationErr != nil {
+					m.SetRcode(req, dns.RcodeServerFailure)
+					if writeErr := w.WriteMsg(m); writeErr != nil {
+						slog.Error(
+							fmt.Sprintf(
+								"failed to write response: %s",
+								writeErr,
+							),
+						)
+					}
+					slog.Error(
+						"failed to load DNSSEC trust anchors",
+						"zone",
+						nameserverDomain,
+						"error",
+						validationErr,
+					)
+					return
+				}
+				ctx.validation = validation
+			}
 
 			// Try all nameservers with retry and failover
 			resp, err := r.queryMultipleNameservers(
@@ -773,7 +842,52 @@ func (r *Resolver) handleQuery(w dns.ResponseWriter, req *dns.Msg) {
 	// Include SOA in authority section for blockchain zones
 	zone := findZoneForName(req.Question[0].Name)
 	if zone != "" {
-		m.Ns = append(m.Ns, generateSyntheticSOA(zone))
+		m.Authoritative = true
+		fromHandshake, sourceErr := localZoneUsesHandshake(zone)
+		if sourceErr != nil {
+			slog.Error(
+				"failed to determine local zone source",
+				"zone",
+				zone,
+				"error",
+				sourceErr,
+			)
+			return
+		}
+		soa, storedSOA, soaErr := lookupLocalSOA(zone, fromHandshake)
+		if soaErr != nil {
+			slog.Error(
+				"failed to lookup local SOA",
+				"zone",
+				zone,
+				"error",
+				soaErr,
+			)
+			return
+		}
+		m.Ns = append(m.Ns, soa)
+		if wantsDNSSEC(req) && storedSOA {
+			rcode, proof, err := lookupLocalNegativeProof(
+				req.Question[0],
+				zone,
+				soa,
+				fromHandshake,
+			)
+			if err != nil {
+				slog.Error(
+					"failed to lookup local DNSSEC denial proof",
+					"zone",
+					zone,
+					"error",
+					err,
+				)
+				return
+			}
+			if len(proof) > 0 {
+				m.Rcode = rcode
+				m.Ns = append(m.Ns, proof...)
+			}
+		}
 	}
 	if err := w.WriteMsg(m); err != nil {
 		slog.Error(
@@ -810,6 +924,212 @@ func stateRecordToDnsRR(record state.DomainRecord) (dns.RR, error) {
 	return dns.NewRR(tmpRR)
 }
 
+func lookupLocalSignatures(
+	recordName string,
+	fromHandshake bool,
+	answer []dns.RR,
+) ([]dns.RR, error) {
+	var (
+		records []state.DomainRecord
+		err     error
+	)
+	if fromHandshake {
+		records, err = state.GetState().LookupHandshakeRecords(
+			[]string{"RRSIG"},
+			recordName,
+		)
+	} else {
+		records, err = state.GetState().LookupRecords(
+			[]string{"RRSIG"},
+			recordName,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	answerTypes := make(map[uint16]struct{}, len(answer))
+	for _, rr := range answer {
+		answerTypes[rr.Header().Rrtype] = struct{}{}
+	}
+	var ret []dns.RR
+	for _, record := range records {
+		rr, err := stateRecordToDnsRR(record)
+		if err != nil {
+			return nil, err
+		}
+		sig, ok := rr.(*dns.RRSIG)
+		if !ok {
+			continue
+		}
+		if _, ok := answerTypes[sig.TypeCovered]; ok {
+			ret = append(ret, sig)
+		}
+	}
+	return ret, nil
+}
+
+func lookupLocalZoneDNSSECRecords(
+	zone string,
+	fromHandshake bool,
+) ([]dns.RR, error) {
+	recordTypes := []string{"NSEC", "NSEC3", "RRSIG"}
+	var (
+		records []state.DomainRecord
+		err     error
+	)
+	if fromHandshake {
+		records, err = state.GetState().LookupHandshakeRecordsInZone(
+			recordTypes,
+			zone,
+		)
+	} else {
+		records, err = state.GetState().LookupRecordsInZone(
+			recordTypes,
+			zone,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]dns.RR, 0, len(records))
+	for _, record := range records {
+		rr, err := stateRecordToDnsRR(record)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, rr)
+	}
+	return ret, nil
+}
+
+func localZoneUsesHandshake(zone string) (bool, error) {
+	recordName := strings.TrimSuffix(canonicalDNSName(zone), ".")
+	cardanoNS, err := state.GetState().LookupRecords(
+		[]string{"NS"},
+		recordName,
+	)
+	if err != nil {
+		return false, err
+	}
+	if len(cardanoNS) > 0 {
+		return false, nil
+	}
+	handshakeNS, err := state.GetState().LookupHandshakeRecords(
+		[]string{"NS"},
+		recordName,
+	)
+	if err != nil {
+		return false, err
+	}
+	return len(handshakeNS) > 0, nil
+}
+
+func lookupLocalSOA(
+	zone string,
+	fromHandshake bool,
+) (*dns.SOA, bool, error) {
+	recordName := strings.TrimSuffix(canonicalDNSName(zone), ".")
+	var (
+		records []state.DomainRecord
+		err     error
+	)
+	if fromHandshake {
+		records, err = state.GetState().LookupHandshakeRecords(
+			[]string{"SOA"},
+			recordName,
+		)
+	} else {
+		records, err = state.GetState().LookupRecords(
+			[]string{"SOA"},
+			recordName,
+		)
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	if len(records) == 0 {
+		return generateSyntheticSOA(zone), false, nil
+	}
+	if len(records) != 1 {
+		return nil, false, fmt.Errorf(
+			"zone %s has %d SOA records, want exactly one",
+			zone,
+			len(records),
+		)
+	}
+	rr, err := stateRecordToDnsRR(records[0])
+	if err != nil {
+		return nil, false, err
+	}
+	soa, ok := rr.(*dns.SOA)
+	if !ok {
+		return nil, false, fmt.Errorf(
+			"stored SOA record for %s parsed as %T",
+			zone,
+			rr,
+		)
+	}
+	return soa, true, nil
+}
+
+func lookupLocalNegativeProof(
+	question dns.Question,
+	zone string,
+	soa *dns.SOA,
+	fromHandshake bool,
+) (int, []dns.RR, error) {
+	records, err := lookupLocalZoneDNSSECRecords(zone, fromHandshake)
+	if err != nil {
+		return 0, nil, err
+	}
+	soaSignatures := signaturesFor(records, soa.Hdr.Name, dns.TypeSOA)
+	if len(soaSignatures) == 0 {
+		return 0, nil, nil
+	}
+
+	qname := canonicalDNSName(question.Name)
+	rcode := dns.RcodeSuccess
+	proof := nodataProofRecords(qname, question.Qtype, records)
+	if len(proof) == 0 {
+		rcode = dns.RcodeNameError
+		proof = nxdomainProofRecords(qname, records)
+	}
+	if len(proof) == 0 {
+		return 0, nil, nil
+	}
+
+	ret := make([]dns.RR, 0, len(proof)*2+len(soaSignatures))
+	for _, signature := range soaSignatures {
+		ret = append(ret, signature)
+	}
+	type rrsetKey struct {
+		name   string
+		rrType uint16
+	}
+	seen := make(map[rrsetKey]struct{}, len(proof))
+	for _, rr := range proof {
+		key := rrsetKey{
+			name:   canonicalDNSName(rr.Header().Name),
+			rrType: rr.Header().Rrtype,
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		rrset := rrsetFrom(records, key.name, key.rrType)
+		signatures := signaturesFor(records, key.name, key.rrType)
+		if len(rrset) == 0 || len(signatures) == 0 {
+			return 0, nil, nil
+		}
+		seen[key] = struct{}{}
+		ret = append(ret, rrset...)
+		for _, signature := range signatures {
+			ret = append(ret, signature)
+		}
+	}
+	return rcode, ret, nil
+}
+
 func copyResponse(req *dns.Msg, srcResp *dns.Msg, destResp *dns.Msg) {
 	if srcResp == nil {
 		return
@@ -818,6 +1138,8 @@ func copyResponse(req *dns.Msg, srcResp *dns.Msg, destResp *dns.Msg) {
 	destResp.SetRcode(req, srcResp.Rcode)
 	destResp.RecursionDesired = req.RecursionDesired
 	destResp.RecursionAvailable = srcResp.RecursionAvailable
+	destResp.AuthenticatedData = srcResp.AuthenticatedData &&
+		(wantsDNSSEC(req) || req.AuthenticatedData)
 	if srcResp.Ns != nil {
 		destResp.Ns = append(destResp.Ns, srcResp.Ns...)
 	}
@@ -826,6 +1148,21 @@ func copyResponse(req *dns.Msg, srcResp *dns.Msg, destResp *dns.Msg) {
 	}
 	if srcResp.Extra != nil {
 		destResp.Extra = append(destResp.Extra, srcResp.Extra...)
+	}
+	if !wantsDNSSEC(req) {
+		requestedType := req.Question[0].Qtype
+		destResp.Answer = filterDNSSECRecords(
+			destResp.Answer,
+			requestedType,
+		)
+		destResp.Ns = filterDNSSECRecords(
+			destResp.Ns,
+			requestedType,
+		)
+		destResp.Extra = filterDNSSECRecords(
+			destResp.Extra,
+			requestedType,
+		)
 	}
 }
 
@@ -946,13 +1283,34 @@ func (r *Resolver) queryMultipleNameserversWithPort(
 	}
 
 	for _, addr := range addresses {
-		client := &dns.Client{
-			Timeout: timeout,
+		if r.dnssecEnabled && !msg.CheckingDisabled {
+			if err := r.ensureDNSSECKeys(
+				ctx.requestCtx,
+				ctx.validation,
+				addr,
+				timeout,
+			); err != nil {
+				slog.Debug(
+					"DNSSEC key authentication failed",
+					"address",
+					addr,
+					"error",
+					err,
+				)
+				lastErr = err
+				continue
+			}
 		}
 		queryFn := func() (*dns.Msg, error) {
-			resp, _, exchangeErr := client.Exchange(
-				msg,
+			outbound := msg
+			if r.dnssecEnabled || wantsDNSSEC(msg) {
+				outbound = dnssecQuery(msg)
+			}
+			resp, exchangeErr := exchangeDNS(
+				ctx.requestCtx,
+				outbound,
 				addr,
+				timeout,
 			)
 			if exchangeErr != nil {
 				return nil, exchangeErr
@@ -995,7 +1353,7 @@ func (r *Resolver) queryMultipleNameserversWithPort(
 		// If recursive and got a referral, follow it
 		if recursive &&
 			!resp.Authoritative &&
-			len(resp.Ns) > 0 {
+			len(getNameserversFromResponse(resp)) > 0 {
 			result, referralErr := r.handleReferral(
 				msg,
 				resp,
@@ -1015,6 +1373,27 @@ func (r *Resolver) queryMultipleNameserversWithPort(
 			continue
 		}
 
+		if r.dnssecEnabled && !msg.CheckingDisabled {
+			authenticated, validationErr := r.validateFinalResponse(
+				msg,
+				resp,
+				ctx.validation,
+			)
+			if validationErr != nil {
+				slog.Debug(
+					"DNSSEC response validation failed",
+					"address",
+					addr,
+					"error",
+					validationErr,
+				)
+				lastErr = validationErr
+				continue
+			}
+			resp.AuthenticatedData = authenticated
+		} else {
+			resp.AuthenticatedData = false
+		}
 		return resp, nil
 	}
 
@@ -1056,8 +1435,20 @@ func (r *Resolver) handleReferral(
 		return resp, nil
 	}
 
-	// Resolve missing glue records
 	childCtx := ctx.descend()
+	if r.dnssecEnabled && !msg.CheckingDisabled {
+		validation, err := r.validationForReferral(
+			resp,
+			ctx.validation,
+			msg.Question[0].Name,
+		)
+		if err != nil {
+			return nil, err
+		}
+		childCtx.validation = validation
+	}
+
+	// Resolve missing glue records
 	for nsName, nsIPs := range nameservers {
 		if len(nsIPs) == 0 {
 			resolvedIPs, err := r.resolveNameserverAddress(
@@ -1280,10 +1671,19 @@ func getNameserversFromResponse(msg *dns.Msg) map[string][]net.IP {
 		// TODO: handle SOA
 		switch v := ns.(type) {
 		case *dns.NS:
-			nsName := v.Ns
+			nsName := canonicalDNSName(v.Ns)
 			ret[nsName] = []net.IP{}
+			// Glue is only authoritative when the nameserver is
+			// beneath the delegated zone. Out-of-bailiwick address
+			// records must be resolved independently.
+			if !dns.IsSubDomain(
+				canonicalDNSName(v.Hdr.Name),
+				nsName,
+			) {
+				continue
+			}
 			for _, extra := range msg.Extra {
-				if extra.Header().Name != nsName {
+				if canonicalDNSName(extra.Header().Name) != nsName {
 					continue
 				}
 				switch v := extra.(type) {

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -666,6 +666,12 @@ func TestThirdPartyDNSDelegation(t *testing.T) {
 				t.Fatalf("unexpected resolver error: %v", err)
 			}
 			ctx := newResolutionContext()
+			queryCtx, cancel := context.WithTimeout(
+				ctx.requestCtx,
+				10*time.Second,
+			)
+			defer cancel()
+			ctx.requestCtx = queryCtx
 			msg := new(dns.Msg)
 			msg.SetQuestion(tc.domain, dns.TypeA)
 
@@ -688,6 +694,55 @@ func TestThirdPartyDNSDelegation(t *testing.T) {
 				t.Log("warning: no answer records returned")
 			}
 		})
+	}
+}
+
+func TestGetNameserversAcceptsOnlyInBailiwickGlue(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.Ns = []dns.RR{
+		&dns.NS{
+			Hdr: dns.RR_Header{
+				Name:   "example.",
+				Rrtype: dns.TypeNS,
+				Class:  dns.ClassINET,
+			},
+			Ns: "NS.EXAMPLE.",
+		},
+		&dns.NS{
+			Hdr: dns.RR_Header{
+				Name:   "example.",
+				Rrtype: dns.TypeNS,
+				Class:  dns.ClassINET,
+			},
+			Ns: "ns.external.",
+		},
+	}
+	msg.Extra = []dns.RR{
+		&dns.A{
+			Hdr: dns.RR_Header{
+				Name:   "ns.example.",
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+			},
+			A: net.ParseIP("192.0.2.1"),
+		},
+		&dns.A{
+			Hdr: dns.RR_Header{
+				Name:   "ns.external.",
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+			},
+			A: net.ParseIP("192.0.2.2"),
+		},
+	}
+
+	got := getNameserversFromResponse(msg)
+	if len(got["ns.example."]) != 1 ||
+		!got["ns.example."][0].Equal(net.ParseIP("192.0.2.1")) {
+		t.Fatalf("in-bailiwick glue = %v, want 192.0.2.1", got)
+	}
+	if len(got["ns.external."]) != 0 {
+		t.Fatalf("accepted out-of-bailiwick glue: %v", got)
 	}
 }
 

--- a/internal/dns/dnssec.go
+++ b/internal/dns/dnssec.go
@@ -1,0 +1,1289 @@
+// Copyright 2026 Blink Labs Software
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package dns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/blinklabs-io/cdnsd/internal/config"
+	"github.com/blinklabs-io/cdnsd/internal/state"
+	"github.com/miekg/dns"
+)
+
+var (
+	errDNSSECBogus = errors.New("DNSSEC validation failed")
+	errNoSignature = errors.New("no valid DNSSEC signature")
+)
+
+// dnssecValidation is the security state for the nameservers at the
+// current point in an iterative lookup. An empty anchor set means the
+// delegation is securely known to be unsigned (or has no configured
+// authentication path).
+type dnssecValidation struct {
+	zone     string
+	anchors  []dns.RR
+	keys     []*dns.DNSKEY
+	insecure bool
+}
+
+func (r *Resolver) loadTrustAnchors(cfg *config.Config) error {
+	r.trustAnchors = make(map[string][]dns.RR)
+	if !cfg.Dns.DNSSEC.Enabled {
+		return nil
+	}
+	for line := range strings.SplitSeq(
+		cfg.Dns.DNSSEC.TrustAnchors,
+		"\n",
+	) {
+		rr, err := dns.NewRR(line)
+		if err != nil {
+			return fmt.Errorf("load DNSSEC trust anchors: %w", err)
+		}
+		if rr == nil {
+			continue
+		}
+		switch rr.(type) {
+		case *dns.DS, *dns.DNSKEY:
+		default:
+			return fmt.Errorf(
+				"load DNSSEC trust anchors: unsupported record type %s",
+				dns.Type(rr.Header().Rrtype),
+			)
+		}
+		if !supportedTrustAnchor(rr) {
+			return fmt.Errorf(
+				"load DNSSEC trust anchors: unsupported %s trust anchor for %s",
+				dns.Type(rr.Header().Rrtype),
+				rr.Header().Name,
+			)
+		}
+		zone := canonicalDNSName(rr.Header().Name)
+		r.trustAnchors[zone] = append(r.trustAnchors[zone], rr)
+	}
+	return nil
+}
+
+func canonicalDNSName(name string) string {
+	return strings.ToLower(dns.CanonicalName(name))
+}
+
+func (r *Resolver) configuredTrustAnchors(zone string) []dns.RR {
+	if r == nil || !r.dnssecEnabled {
+		return nil
+	}
+	return slices.Clone(r.trustAnchors[canonicalDNSName(zone)])
+}
+
+// trustAnchorsForZone combines operator-configured anchors with DS
+// records authenticated by the Cardano or Handshake chain. This is
+// the key multi-root property: each blockchain root can establish its
+// own DNSSEC island without pretending to descend from the ICANN root.
+func (r *Resolver) trustAnchorsForZone(zone string) ([]dns.RR, error) {
+	anchors := r.configuredTrustAnchors(zone)
+	if !r.dnssecEnabled || !stateAvailable() {
+		return anchors, nil
+	}
+
+	recordName := strings.TrimSuffix(canonicalDNSName(zone), ".")
+	cardanoNS, err := state.GetState().LookupRecords(
+		[]string{"NS"},
+		recordName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	handshakeNS, err := state.GetState().LookupHandshakeRecords(
+		[]string{"NS"},
+		recordName,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var records []state.DomainRecord
+	switch {
+	case cardanoNS != nil:
+		// Cardano records take precedence throughout the resolver.
+		// Do not accidentally pair that delegation with a same-named
+		// Handshake DS record from another root.
+		records, err = state.GetState().LookupRecords(
+			[]string{"DS"},
+			recordName,
+		)
+	case handshakeNS != nil:
+		records, err = state.GetState().LookupHandshakeRecords(
+			[]string{"DS"},
+			recordName,
+		)
+	default:
+		records, err = state.GetState().LookupRecords(
+			[]string{"DS"},
+			recordName,
+		)
+		if err == nil && records == nil {
+			records, err = state.GetState().LookupHandshakeRecords(
+				[]string{"DS"},
+				recordName,
+			)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	for _, record := range records {
+		rr, err := stateRecordToDnsRR(record)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"parse on-chain DNSSEC anchor for %s: %w",
+				zone,
+				err,
+			)
+		}
+		if _, ok := rr.(*dns.DS); !ok ||
+			!supportedTrustAnchor(rr) {
+			continue
+		}
+		anchors = append(anchors, rr)
+	}
+	return anchors, nil
+}
+
+func (r *Resolver) dnssecContextForZone(
+	zone string,
+	includeOnChain bool,
+) (*dnssecValidation, error) {
+	if r == nil || !r.dnssecEnabled {
+		return nil, nil
+	}
+	var (
+		anchors []dns.RR
+		err     error
+	)
+	if includeOnChain {
+		anchors, err = r.trustAnchorsForZone(zone)
+	} else {
+		anchors = r.configuredTrustAnchors(zone)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &dnssecValidation{
+		zone:     canonicalDNSName(zone),
+		anchors:  anchors,
+		insecure: len(anchors) == 0,
+	}, nil
+}
+
+func dnssecQuery(msg *dns.Msg) *dns.Msg {
+	ret := msg.Copy()
+	ret.AuthenticatedData = false
+	// We perform validation locally and do not want an upstream
+	// recursive server to suppress data it considers bogus.
+	ret.CheckingDisabled = true
+	opt := ret.IsEdns0()
+	if opt == nil {
+		ret.SetEdns0(1232, true)
+	} else {
+		opt.SetDo()
+		if opt.UDPSize() < 512 {
+			opt.SetUDPSize(1232)
+		}
+	}
+	return ret
+}
+
+func wantsDNSSEC(msg *dns.Msg) bool {
+	if msg == nil {
+		return false
+	}
+	opt := msg.IsEdns0()
+	return opt != nil && opt.Do()
+}
+
+func exchangeDNS(
+	ctx context.Context,
+	msg *dns.Msg,
+	address string,
+	timeout time.Duration,
+) (*dns.Msg, error) {
+	client := &dns.Client{Timeout: timeout}
+	resp, _, err := client.ExchangeContext(ctx, msg, address)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || !resp.Truncated {
+		return resp, nil
+	}
+	tcpClient := &dns.Client{
+		Net:     "tcp",
+		Timeout: timeout,
+	}
+	resp, _, err = tcpClient.ExchangeContext(ctx, msg, address)
+	return resp, err
+}
+
+func (r *Resolver) ensureDNSSECKeys(
+	ctx context.Context,
+	validation *dnssecValidation,
+	address string,
+	timeout time.Duration,
+) error {
+	if validation == nil || validation.insecure ||
+		len(validation.keys) > 0 {
+		return nil
+	}
+	if len(validation.anchors) == 0 {
+		validation.insecure = true
+		return nil
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion(validation.zone, dns.TypeDNSKEY)
+	resp, err := exchangeDNS(ctx, dnssecQuery(msg), address, timeout)
+	if err != nil {
+		return fmt.Errorf("%w: fetch DNSKEY for %s: %w",
+			errDNSSECBogus,
+			validation.zone,
+			err,
+		)
+	}
+	if resp == nil || resp.Rcode != dns.RcodeSuccess {
+		return fmt.Errorf(
+			"%w: DNSKEY query for %s returned %s",
+			errDNSSECBogus,
+			validation.zone,
+			rcodeString(resp),
+		)
+	}
+
+	keys := dnskeysFrom(resp.Answer, validation.zone)
+	if len(keys) == 0 {
+		return fmt.Errorf(
+			"%w: no DNSKEY records for %s",
+			errDNSSECBogus,
+			validation.zone,
+		)
+	}
+	rrset := make([]dns.RR, 0, len(keys))
+	for _, key := range keys {
+		rrset = append(rrset, key)
+	}
+	sigs := signaturesFor(
+		resp.Answer,
+		validation.zone,
+		dns.TypeDNSKEY,
+	)
+	if err := authenticateDNSKEYSet(
+		rrset,
+		sigs,
+		keys,
+		validation.anchors,
+	); err != nil {
+		return fmt.Errorf(
+			"%w: authenticate DNSKEY for %s: %w",
+			errDNSSECBogus,
+			validation.zone,
+			err,
+		)
+	}
+	validation.keys = activeDNSSECKeys(keys)
+	if len(validation.keys) == 0 {
+		return fmt.Errorf(
+			"%w: no active DNSKEY records for %s",
+			errDNSSECBogus,
+			validation.zone,
+		)
+	}
+	return nil
+}
+
+func activeDNSSECKeys(keys []*dns.DNSKEY) []*dns.DNSKEY {
+	return slices.DeleteFunc(
+		slices.Clone(keys),
+		func(key *dns.DNSKEY) bool {
+			return key == nil ||
+				key.Protocol != 3 ||
+				key.Flags&dns.ZONE == 0 ||
+				key.Flags&dns.REVOKE != 0 ||
+				!supportedDNSSECAlgorithm(key.Algorithm)
+		},
+	)
+}
+
+func rcodeString(msg *dns.Msg) string {
+	if msg == nil {
+		return "nil response"
+	}
+	if name, ok := dns.RcodeToString[msg.Rcode]; ok {
+		return name
+	}
+	return fmt.Sprintf("RCODE%d", msg.Rcode)
+}
+
+func dnskeysFrom(section []dns.RR, zone string) []*dns.DNSKEY {
+	zone = canonicalDNSName(zone)
+	var ret []*dns.DNSKEY
+	for _, rr := range section {
+		key, ok := rr.(*dns.DNSKEY)
+		if ok && canonicalDNSName(key.Hdr.Name) == zone {
+			ret = append(ret, key)
+		}
+	}
+	return ret
+}
+
+func signaturesFor(
+	section []dns.RR,
+	name string,
+	rrType uint16,
+) []*dns.RRSIG {
+	name = canonicalDNSName(name)
+	var ret []*dns.RRSIG
+	for _, rr := range section {
+		sig, ok := rr.(*dns.RRSIG)
+		if !ok ||
+			sig.TypeCovered != rrType ||
+			canonicalDNSName(sig.Hdr.Name) != name {
+			continue
+		}
+		ret = append(ret, sig)
+	}
+	return ret
+}
+
+func authenticateDNSKEYSet(
+	rrset []dns.RR,
+	sigs []*dns.RRSIG,
+	keys []*dns.DNSKEY,
+	anchors []dns.RR,
+) error {
+	var trustedKeys []*dns.DNSKEY
+	for _, key := range keys {
+		for _, anchor := range anchors {
+			if dnskeyMatchesAnchor(key, anchor) {
+				trustedKeys = append(trustedKeys, key)
+				break
+			}
+		}
+	}
+	if len(trustedKeys) == 0 {
+		return errors.New("no DNSKEY matches a trust anchor")
+	}
+	return verifyRRSet(rrset, sigs, trustedKeys)
+}
+
+func dnskeyMatchesAnchor(key *dns.DNSKEY, anchor dns.RR) bool {
+	if key == nil || anchor == nil ||
+		canonicalDNSName(key.Hdr.Name) !=
+			canonicalDNSName(anchor.Header().Name) {
+		return false
+	}
+	switch value := anchor.(type) {
+	case *dns.DS:
+		if value.KeyTag != key.KeyTag() ||
+			value.Algorithm != key.Algorithm {
+			return false
+		}
+		derived := key.ToDS(value.DigestType)
+		return derived != nil &&
+			strings.EqualFold(derived.Digest, value.Digest)
+	case *dns.DNSKEY:
+		return value.Flags == key.Flags &&
+			value.Protocol == key.Protocol &&
+			value.Algorithm == key.Algorithm &&
+			value.PublicKey == key.PublicKey
+	default:
+		return false
+	}
+}
+
+func verifyRRSet(
+	rrset []dns.RR,
+	sigs []*dns.RRSIG,
+	keys []*dns.DNSKEY,
+) error {
+	if len(rrset) == 0 {
+		return errors.New("empty RRset")
+	}
+	now := time.Now()
+	for _, sig := range sigs {
+		if sig == nil ||
+			sig.TypeCovered != rrset[0].Header().Rrtype ||
+			!supportedDNSSECAlgorithm(sig.Algorithm) ||
+			!dns.IsSubDomain(
+				sig.SignerName,
+				rrset[0].Header().Name,
+			) ||
+			!sig.ValidityPeriod(now) {
+			continue
+		}
+		for _, key := range keys {
+			if key == nil ||
+				key.Protocol != 3 ||
+				key.Flags&dns.ZONE == 0 ||
+				key.Flags&dns.REVOKE != 0 ||
+				!supportedDNSSECAlgorithm(key.Algorithm) ||
+				sig.KeyTag != key.KeyTag() ||
+				sig.Algorithm != key.Algorithm ||
+				canonicalDNSName(sig.SignerName) !=
+					canonicalDNSName(key.Hdr.Name) {
+				continue
+			}
+			if err := sig.Verify(key, rrset); err == nil {
+				normalizeValidatedTTL(rrset, sigs, sig, now)
+				return nil
+			}
+		}
+	}
+	return errNoSignature
+}
+
+func normalizeValidatedTTL(
+	rrset []dns.RR,
+	sigs []*dns.RRSIG,
+	validSig *dns.RRSIG,
+	now time.Time,
+) {
+	ttl := validSig.OrigTtl
+	const serialPeriod = int64(1 << 31)
+	nowUnix := now.UTC().Unix()
+	expiration := int64(validSig.Expiration)
+	expiration += (expiration - nowUnix) / serialPeriod * serialPeriod
+	remaining := expiration - nowUnix
+	if remaining >= 0 && remaining < int64(ttl) {
+		// remaining is non-negative and less than the uint32 TTL.
+		// #nosec G115 -- the bounds check above makes the cast safe.
+		ttl = uint32(remaining)
+	}
+	for _, rr := range rrset {
+		if rr.Header().Ttl < ttl {
+			ttl = rr.Header().Ttl
+		}
+	}
+	for _, sig := range sigs {
+		if sig != nil && sig.Hdr.Ttl < ttl {
+			ttl = sig.Hdr.Ttl
+		}
+	}
+	for _, rr := range rrset {
+		rr.Header().Ttl = ttl
+	}
+	for _, sig := range sigs {
+		if sig != nil {
+			sig.Hdr.Ttl = ttl
+		}
+	}
+}
+
+func delegationZone(resp *dns.Msg) (string, error) {
+	if resp == nil {
+		return "", errors.New("referral has no delegation zone")
+	}
+	var zone string
+	for _, rr := range resp.Ns {
+		if ns, ok := rr.(*dns.NS); ok {
+			owner := canonicalDNSName(ns.Hdr.Name)
+			if zone != "" && owner != zone {
+				return "", fmt.Errorf(
+					"%w: referral has multiple delegation zones",
+					errDNSSECBogus,
+				)
+			}
+			zone = owner
+		}
+	}
+	if zone == "" {
+		return "", errors.New("referral has no delegation zone")
+	}
+	return zone, nil
+}
+
+func (r *Resolver) validationForReferral(
+	resp *dns.Msg,
+	parent *dnssecValidation,
+	qname string,
+) (*dnssecValidation, error) {
+	childZone, err := delegationZone(resp)
+	if err != nil {
+		return nil, err
+	}
+	if parent == nil ||
+		childZone == canonicalDNSName(parent.zone) ||
+		!dns.IsSubDomain(parent.zone, childZone) ||
+		!dns.IsSubDomain(childZone, qname) {
+		return nil, fmt.Errorf(
+			"%w: unrelated delegation zone %s",
+			errDNSSECBogus,
+			childZone,
+		)
+	}
+
+	// An explicit anchor starts (or re-establishes) an island of
+	// security even when its parent root is unrelated or unsigned.
+	configured := r.configuredTrustAnchors(childZone)
+	if parent.insecure {
+		return &dnssecValidation{
+			zone:     childZone,
+			anchors:  configured,
+			insecure: len(configured) == 0,
+		}, nil
+	}
+	if len(parent.keys) == 0 {
+		return nil, errors.New("parent DNSKEY set is not authenticated")
+	}
+
+	dsRRset := rrsetFrom(resp.Ns, childZone, dns.TypeDS)
+	if len(dsRRset) > 0 {
+		sigs := signaturesFor(resp.Ns, childZone, dns.TypeDS)
+		if err := verifyRRSet(dsRRset, sigs, parent.keys); err != nil {
+			return nil, fmt.Errorf(
+				"%w: invalid DS RRset for %s: %w",
+				errDNSSECBogus,
+				childZone,
+				err,
+			)
+		}
+		supportedAnchors := supportedDSAnchors(dsRRset)
+		if len(supportedAnchors) == 0 {
+			return &dnssecValidation{
+				zone:     childZone,
+				insecure: true,
+			}, nil
+		}
+		return &dnssecValidation{
+			zone:    childZone,
+			anchors: supportedAnchors,
+		}, nil
+	}
+
+	if len(configured) > 0 {
+		return &dnssecValidation{
+			zone:    childZone,
+			anchors: configured,
+		}, nil
+	}
+	if err := validateNoDSProof(
+		childZone,
+		resp.Ns,
+		parent.keys,
+	); err != nil {
+		return nil, fmt.Errorf(
+			"%w: unauthenticated unsigned delegation for %s: %w",
+			errDNSSECBogus,
+			childZone,
+			err,
+		)
+	}
+	return &dnssecValidation{
+		zone:     childZone,
+		insecure: true,
+	}, nil
+}
+
+func rrsetFrom(
+	section []dns.RR,
+	name string,
+	rrType uint16,
+) []dns.RR {
+	name = canonicalDNSName(name)
+	var ret []dns.RR
+	for _, rr := range section {
+		if rr.Header().Rrtype == rrType &&
+			canonicalDNSName(rr.Header().Name) == name {
+			ret = append(ret, rr)
+		}
+	}
+	return ret
+}
+
+func validateNoDSProof(
+	childZone string,
+	section []dns.RR,
+	keys []*dns.DNSKEY,
+) error {
+	proofs := denialProofRecords(section)
+	if err := validateSectionRRsets(proofs, keys); err != nil {
+		return err
+	}
+	var nsec3s []*dns.NSEC3
+	for _, rr := range proofs {
+		if nsec3, ok := rr.(*dns.NSEC3); ok {
+			nsec3s = append(nsec3s, nsec3)
+		}
+	}
+	for _, rr := range section {
+		switch value := rr.(type) {
+		case *dns.NSEC:
+			if canonicalDNSName(value.Hdr.Name) ==
+				canonicalDNSName(childZone) &&
+				hasType(value.TypeBitMap, dns.TypeNS) &&
+				!hasType(value.TypeBitMap, dns.TypeDS) &&
+				!hasType(value.TypeBitMap, dns.TypeSOA) {
+				return nil
+			}
+		case *dns.NSEC3:
+			if validNSEC3(value) && value.Match(childZone) {
+				if hasType(value.TypeBitMap, dns.TypeNS) &&
+					!hasType(value.TypeBitMap, dns.TypeDS) &&
+					!hasType(value.TypeBitMap, dns.TypeSOA) {
+					return nil
+				}
+			}
+		}
+	}
+	_, _, nextCloserProof := nsec3ClosestEncloserProof(
+		childZone,
+		nsec3s,
+	)
+	if nextCloserProof != nil && nextCloserProof.Flags&1 != 0 {
+		return nil
+	}
+	return errors.New("missing signed NSEC/NSEC3 no-DS proof")
+}
+
+func hasType(types []uint16, rrType uint16) bool {
+	return slices.Contains(types, rrType)
+}
+
+func supportedDSAnchors(records []dns.RR) []dns.RR {
+	var ret []dns.RR
+	for _, rr := range records {
+		ds, ok := rr.(*dns.DS)
+		if !ok ||
+			!supportedDSAlgorithm(ds.Algorithm) ||
+			!supportedDSDigest(ds.DigestType) {
+			continue
+		}
+		ret = append(ret, ds)
+	}
+	return ret
+}
+
+func supportedTrustAnchor(anchor dns.RR) bool {
+	switch value := anchor.(type) {
+	case *dns.DS:
+		return value != nil &&
+			supportedDSAlgorithm(value.Algorithm) &&
+			supportedDSDigest(value.DigestType)
+	case *dns.DNSKEY:
+		return value != nil &&
+			value.Protocol == 3 &&
+			value.Flags&dns.ZONE != 0 &&
+			value.Flags&dns.REVOKE == 0 &&
+			supportedDNSSECAlgorithm(value.Algorithm)
+	default:
+		return false
+	}
+}
+
+func supportedDNSSECAlgorithm(algorithm uint8) bool {
+	switch algorithm {
+	case dns.RSASHA1,
+		dns.RSASHA1NSEC3SHA1,
+		dns.RSASHA256,
+		dns.RSASHA512,
+		dns.ECDSAP256SHA256,
+		dns.ECDSAP384SHA384,
+		dns.ED25519:
+		return true
+	default:
+		return false
+	}
+}
+
+func supportedDSAlgorithm(algorithm uint8) bool {
+	// RFC 9905 requires RSASHA1 DS records to be treated as
+	// insecure, while implementations must retain support for
+	// validating legacy RSASHA1 DNSKEY/RRSIG records.
+	return algorithm != dns.RSASHA1 &&
+		algorithm != dns.RSASHA1NSEC3SHA1 &&
+		supportedDNSSECAlgorithm(algorithm)
+}
+
+func supportedDSDigest(digest uint8) bool {
+	switch digest {
+	case dns.SHA1, dns.SHA256, dns.SHA384:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *Resolver) validateFinalResponse(
+	query *dns.Msg,
+	resp *dns.Msg,
+	validation *dnssecValidation,
+) (bool, error) {
+	if validation == nil || validation.insecure ||
+		query.CheckingDisabled {
+		return false, nil
+	}
+	if len(validation.keys) == 0 {
+		return false, fmt.Errorf(
+			"%w: no authenticated keys for %s",
+			errDNSSECBogus,
+			validation.zone,
+		)
+	}
+
+	// RRSIG records do not themselves form a signed RRset. Answering
+	// an explicit RRSIG query is therefore valid, but cannot carry AD
+	// without separately fetching every covered RRset.
+	if len(query.Question) == 1 &&
+		query.Question[0].Qtype == dns.TypeRRSIG {
+		return false, nil
+	}
+
+	if len(resp.Answer) > 0 {
+		if err := validateSectionRRsets(
+			resp.Answer,
+			validation.keys,
+		); err != nil {
+			return false, fmt.Errorf("%w: %w", errDNSSECBogus, err)
+		}
+		if len(resp.Ns) > 0 {
+			if err := validateSectionRRsets(
+				resp.Ns,
+				validation.keys,
+			); err != nil {
+				return false, fmt.Errorf(
+					"%w: validate authority section: %w",
+					errDNSSECBogus,
+					err,
+				)
+			}
+		}
+		if err := validateWildcardProofs(
+			resp,
+			validation.keys,
+		); err != nil {
+			return false, fmt.Errorf("%w: %w", errDNSSECBogus, err)
+		}
+		return true, nil
+	}
+
+	if resp.Rcode != dns.RcodeSuccess &&
+		resp.Rcode != dns.RcodeNameError {
+		return false, nil
+	}
+	if len(query.Question) != 1 {
+		return false, errors.New("DNSSEC query has no question")
+	}
+	if err := validateNegativeResponse(
+		query.Question[0],
+		resp,
+		validation.keys,
+	); err != nil {
+		return false, fmt.Errorf("%w: %w", errDNSSECBogus, err)
+	}
+	return true, nil
+}
+
+func validateSectionRRsets(
+	section []dns.RR,
+	keys []*dns.DNSKEY,
+) error {
+	type rrsetKey struct {
+		name   string
+		rrType uint16
+		class  uint16
+	}
+	rrsets := make(map[rrsetKey][]dns.RR)
+	for _, rr := range section {
+		if rr.Header().Rrtype == dns.TypeRRSIG {
+			continue
+		}
+		key := rrsetKey{
+			name:   canonicalDNSName(rr.Header().Name),
+			rrType: rr.Header().Rrtype,
+			class:  rr.Header().Class,
+		}
+		rrsets[key] = append(rrsets[key], rr)
+	}
+	for key, rrset := range rrsets {
+		sigs := signaturesFor(section, key.name, key.rrType)
+		if err := verifyRRSet(rrset, sigs, keys); err != nil {
+			return fmt.Errorf(
+				"validate %s/%s: %w",
+				key.name,
+				dns.Type(key.rrType),
+				err,
+			)
+		}
+	}
+	if len(rrsets) == 0 {
+		return errors.New("response contains no signed RRsets")
+	}
+	return nil
+}
+
+func validateWildcardProofs(
+	resp *dns.Msg,
+	keys []*dns.DNSKEY,
+) error {
+	for _, rr := range resp.Answer {
+		sig, ok := rr.(*dns.RRSIG)
+		if !ok ||
+			int(sig.Labels) >= dns.CountLabel(sig.Hdr.Name) {
+			continue
+		}
+		rrset := rrsetFrom(
+			resp.Answer,
+			sig.Hdr.Name,
+			sig.TypeCovered,
+		)
+		if err := verifyRRSet(
+			rrset,
+			[]*dns.RRSIG{sig},
+			keys,
+		); err != nil {
+			// Another valid signature may cover this RRset without
+			// wildcard expansion.
+			continue
+		}
+
+		proofs := denialProofRecords(resp.Ns)
+		if err := validateSectionRRsets(proofs, keys); err != nil {
+			return fmt.Errorf(
+				"validate wildcard denial proof for %s: %w",
+				sig.Hdr.Name,
+				err,
+			)
+		}
+		closest, nextCloser := wildcardClosestNames(
+			sig.Hdr.Name,
+			int(sig.Labels),
+		)
+		nsecProves := false
+		var nsec3s []*dns.NSEC3
+		for _, proof := range proofs {
+			switch value := proof.(type) {
+			case *dns.NSEC:
+				nsecProves = nsecProves ||
+					nsecCovers(value, nextCloser)
+			case *dns.NSEC3:
+				if validNSEC3(value) {
+					nsec3s = append(nsec3s, value)
+				}
+			}
+		}
+		nsec3Proves := false
+		for _, closestProof := range nsec3s {
+			if !closestProof.Match(closest) {
+				continue
+			}
+			for _, nextCloserProof := range nsec3s {
+				if sameNSEC3Parameters(
+					closestProof,
+					nextCloserProof,
+				) && nextCloserProof.Cover(nextCloser) {
+					nsec3Proves = true
+					break
+				}
+			}
+		}
+		if !nsecProves && !nsec3Proves {
+			return fmt.Errorf(
+				"denial records do not authenticate wildcard answer for %s",
+				sig.Hdr.Name,
+			)
+		}
+	}
+	return nil
+}
+
+func denialProofRecords(section []dns.RR) []dns.RR {
+	var ret []dns.RR
+	for _, rr := range section {
+		switch rr.Header().Rrtype {
+		case dns.TypeNSEC, dns.TypeNSEC3:
+			ret = append(ret, rr)
+		case dns.TypeRRSIG:
+			sig, ok := rr.(*dns.RRSIG)
+			if ok && (sig.TypeCovered == dns.TypeNSEC ||
+				sig.TypeCovered == dns.TypeNSEC3) {
+				ret = append(ret, rr)
+			}
+		}
+	}
+	return ret
+}
+
+func wildcardClosestNames(name string, labels int) (string, string) {
+	nameLabels := dns.SplitDomainName(name)
+	if len(nameLabels) == 0 {
+		return ".", canonicalDNSName(name)
+	}
+	if labels < 0 {
+		labels = 0
+	}
+	if labels > len(nameLabels) {
+		labels = len(nameLabels)
+	}
+	closest := "."
+	if labels > 0 {
+		closest = dns.Fqdn(
+			strings.Join(nameLabels[len(nameLabels)-labels:], "."),
+		)
+	}
+	return closest, nextCloserName(name, closest)
+}
+
+func validateNegativeResponse(
+	question dns.Question,
+	resp *dns.Msg,
+	keys []*dns.DNSKEY,
+) error {
+	// The SOA and denial records must all be authentic. Semantic
+	// checks below then ensure they actually prove this question.
+	var denialRecords []dns.RR
+	for _, rr := range resp.Ns {
+		switch rr.Header().Rrtype {
+		case dns.TypeSOA, dns.TypeNSEC, dns.TypeNSEC3:
+			denialRecords = append(denialRecords, rr)
+		case dns.TypeRRSIG:
+			sig, ok := rr.(*dns.RRSIG)
+			if ok && (sig.TypeCovered == dns.TypeSOA ||
+				sig.TypeCovered == dns.TypeNSEC ||
+				sig.TypeCovered == dns.TypeNSEC3) {
+				denialRecords = append(denialRecords, rr)
+			}
+		}
+	}
+	if err := validateSectionRRsets(resp.Ns, keys); err != nil {
+		return err
+	}
+
+	qname := canonicalDNSName(question.Name)
+	if resp.Rcode == dns.RcodeSuccess {
+		if provesNODATA(qname, question.Qtype, denialRecords) {
+			return nil
+		}
+		return errors.New("denial records do not prove NODATA")
+	}
+
+	if !provesNXDOMAIN(qname, denialRecords) {
+		return errors.New("denial records do not prove NXDOMAIN")
+	}
+	return nil
+}
+
+func provesNODATA(name string, qtype uint16, records []dns.RR) bool {
+	return len(nodataProofRecords(name, qtype, records)) > 0
+}
+
+func nodataProofRecords(
+	name string,
+	qtype uint16,
+	records []dns.RR,
+) []dns.RR {
+	var (
+		nsecs  []*dns.NSEC
+		nsec3s []*dns.NSEC3
+	)
+	for _, rr := range records {
+		switch value := rr.(type) {
+		case *dns.NSEC:
+			nsecs = append(nsecs, value)
+		case *dns.NSEC3:
+			nsec3s = append(nsec3s, value)
+		}
+	}
+
+	typeAbsent := func(types []uint16) bool {
+		return !hasType(types, qtype) &&
+			!hasType(types, dns.TypeCNAME)
+	}
+	for _, rr := range nsecs {
+		if canonicalDNSName(rr.Hdr.Name) == name &&
+			typeAbsent(rr.TypeBitMap) {
+			return []dns.RR{rr}
+		}
+		// RFC 8198 Appendix B identifies an empty non-terminal when
+		// a covering NSEC's next name is beneath the queried name.
+		if nsecCovers(rr, name) &&
+			dns.IsSubDomain(name, rr.NextDomain) &&
+			canonicalDNSName(rr.NextDomain) != name {
+			return []dns.RR{rr}
+		}
+	}
+	for _, wildcard := range nsecs {
+		owner := canonicalDNSName(wildcard.Hdr.Name)
+		if !strings.HasPrefix(owner, "*.") ||
+			!typeAbsent(wildcard.TypeBitMap) {
+			continue
+		}
+		closest := strings.TrimPrefix(owner, "*.")
+		if !dns.IsSubDomain(closest, name) {
+			continue
+		}
+		if slices.ContainsFunc(
+			nsecs,
+			func(rr *dns.NSEC) bool { return nsecCovers(rr, name) },
+		) {
+			for _, cover := range nsecs {
+				if nsecCovers(cover, name) {
+					return uniqueDenialRecords(wildcard, cover)
+				}
+			}
+		}
+	}
+
+	for _, rr := range nsec3s {
+		if validNSEC3(rr) && rr.Match(name) &&
+			typeAbsent(rr.TypeBitMap) {
+			return []dns.RR{rr}
+		}
+	}
+	closest, closestProof, nextCloserProof := nsec3ClosestEncloserProof(
+		name,
+		nsec3s,
+	)
+	if nextCloserProof == nil {
+		return nil
+	}
+	// Verified RFC 5155 erratum 3441 permits an opt-out closest
+	// encloser proof for an empty non-terminal.
+	if nextCloserProof.Flags&1 != 0 {
+		return uniqueDenialRecords(closestProof, nextCloserProof)
+	}
+	wildcard := wildcardName(closest)
+	for _, rr := range nsec3s {
+		if sameNSEC3Parameters(rr, nextCloserProof) &&
+			rr.Match(wildcard) &&
+			typeAbsent(rr.TypeBitMap) {
+			return uniqueDenialRecords(
+				closestProof,
+				nextCloserProof,
+				rr,
+			)
+		}
+	}
+	return nil
+}
+
+func provesNXDOMAIN(name string, records []dns.RR) bool {
+	return len(nxdomainProofRecords(name, records)) > 0
+}
+
+func nxdomainProofRecords(name string, records []dns.RR) []dns.RR {
+	var (
+		nsecs  []*dns.NSEC
+		nsec3s []*dns.NSEC3
+	)
+	for _, rr := range records {
+		switch value := rr.(type) {
+		case *dns.NSEC:
+			nsecs = append(nsecs, value)
+		case *dns.NSEC3:
+			nsec3s = append(nsec3s, value)
+		}
+	}
+
+	ancestors := nameAncestors(name)
+	for _, closest := range ancestors {
+		exists := false
+		for _, rr := range nsecs {
+			if canonicalDNSName(rr.Hdr.Name) ==
+				canonicalDNSName(closest) {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			continue
+		}
+		nameDenied := slices.ContainsFunc(
+			nsecs,
+			func(rr *dns.NSEC) bool { return nsecCovers(rr, name) },
+		)
+		wildcard := wildcardName(closest)
+		wildcardDenied := slices.ContainsFunc(
+			nsecs,
+			func(rr *dns.NSEC) bool {
+				return nsecCovers(rr, wildcard)
+			},
+		)
+		if nameDenied && wildcardDenied {
+			var ret []dns.RR
+			for _, rr := range nsecs {
+				if canonicalDNSName(rr.Hdr.Name) ==
+					canonicalDNSName(closest) ||
+					nsecCovers(rr, name) ||
+					nsecCovers(rr, wildcard) {
+					ret = append(ret, rr)
+				}
+			}
+			return uniqueDenialRecords(ret...)
+		}
+		break
+	}
+
+	closest, closestProof, nextCloserProof := nsec3ClosestEncloserProof(
+		name,
+		nsec3s,
+	)
+	if nextCloserProof != nil {
+		wildcard := wildcardName(closest)
+		for _, rr := range nsec3s {
+			if sameNSEC3Parameters(rr, nextCloserProof) &&
+				rr.Cover(wildcard) {
+				return uniqueDenialRecords(
+					closestProof,
+					nextCloserProof,
+					rr,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func uniqueDenialRecords(records ...dns.RR) []dns.RR {
+	ret := make([]dns.RR, 0, len(records))
+	for _, rr := range records {
+		if rr == nil || slices.Contains(ret, rr) {
+			continue
+		}
+		ret = append(ret, rr)
+	}
+	return ret
+}
+
+func nsec3ClosestEncloserProof(
+	name string,
+	records []*dns.NSEC3,
+) (string, *dns.NSEC3, *dns.NSEC3) {
+	for _, closest := range nameAncestors(name) {
+		for _, match := range records {
+			if !validNSEC3(match) || !match.Match(closest) ||
+				hasType(match.TypeBitMap, dns.TypeDNAME) ||
+				(hasType(match.TypeBitMap, dns.TypeNS) &&
+					!hasType(match.TypeBitMap, dns.TypeSOA)) {
+				continue
+			}
+			nextCloser := nextCloserName(name, closest)
+			for _, cover := range records {
+				if sameNSEC3Parameters(match, cover) &&
+					cover.Cover(nextCloser) {
+					return closest, match, cover
+				}
+			}
+		}
+	}
+	return "", nil, nil
+}
+
+func validNSEC3(rr *dns.NSEC3) bool {
+	// RFC 9276 identifies 500 as an interoperable SERVFAIL
+	// threshold and warns that accepting the uint16 maximum exposes
+	// public resolvers to CPU exhaustion.
+	const maxNSEC3Iterations = 500
+	return rr != nil &&
+		rr.Hash == dns.SHA1 &&
+		rr.Flags <= 1 &&
+		rr.Iterations <= maxNSEC3Iterations
+}
+
+func sameNSEC3Parameters(left *dns.NSEC3, right *dns.NSEC3) bool {
+	return validNSEC3(left) &&
+		validNSEC3(right) &&
+		left.Hash == right.Hash &&
+		left.Iterations == right.Iterations &&
+		strings.EqualFold(left.Salt, right.Salt)
+}
+
+func nameAncestors(name string) []string {
+	labels := dns.SplitDomainName(name)
+	ret := make([]string, 0, len(labels))
+	for i := 1; i < len(labels); i++ {
+		ret = append(
+			ret,
+			dns.Fqdn(strings.Join(labels[i:], ".")),
+		)
+	}
+	ret = append(ret, ".")
+	return ret
+}
+
+func nextCloserName(name string, closest string) string {
+	nameLabels := dns.SplitDomainName(name)
+	closestLabels := dns.SplitDomainName(closest)
+	if len(nameLabels) <= len(closestLabels) {
+		return canonicalDNSName(name)
+	}
+	start := len(nameLabels) - len(closestLabels) - 1
+	return dns.Fqdn(strings.Join(nameLabels[start:], "."))
+}
+
+func wildcardName(closest string) string {
+	if canonicalDNSName(closest) == "." {
+		return "*."
+	}
+	return dns.Fqdn("*." + closest)
+}
+
+func nsecCovers(rr *dns.NSEC, name string) bool {
+	if rr == nil {
+		return false
+	}
+	owner := canonicalDNSName(rr.Hdr.Name)
+	next := canonicalDNSName(rr.NextDomain)
+	name = canonicalDNSName(name)
+	if owner == name {
+		return false
+	}
+	if canonicalNameLess(owner, next) {
+		return canonicalNameLess(owner, name) &&
+			canonicalNameLess(name, next)
+	}
+	// The final NSEC RR wraps around to the start of the zone.
+	return canonicalNameLess(owner, name) ||
+		canonicalNameLess(name, next)
+}
+
+// canonicalNameLess implements the DNSSEC canonical name ordering
+// from RFC 4034 section 6.1: compare labels from the root outwards.
+func canonicalNameLess(left string, right string) bool {
+	lhs := dns.SplitDomainName(strings.ToLower(left))
+	rhs := dns.SplitDomainName(strings.ToLower(right))
+	for len(lhs) > 0 && len(rhs) > 0 {
+		leftLabel := lhs[len(lhs)-1]
+		rightLabel := rhs[len(rhs)-1]
+		if leftLabel != rightLabel {
+			return leftLabel < rightLabel
+		}
+		lhs = lhs[:len(lhs)-1]
+		rhs = rhs[:len(rhs)-1]
+	}
+	return len(lhs) < len(rhs)
+}
+
+func filterDNSSECRecords(
+	records []dns.RR,
+	requestedType uint16,
+) []dns.RR {
+	ret := make([]dns.RR, 0, len(records))
+	for _, rr := range records {
+		switch rr.Header().Rrtype {
+		case dns.TypeRRSIG, dns.TypeNSEC, dns.TypeNSEC3:
+			if rr.Header().Rrtype != requestedType {
+				continue
+			}
+		default:
+			ret = append(ret, rr)
+			continue
+		}
+		ret = append(ret, rr)
+	}
+	return ret
+}

--- a/internal/dns/dnssec_test.go
+++ b/internal/dns/dnssec_test.go
@@ -1,0 +1,1425 @@
+// Copyright 2026 Blink Labs Software
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package dns
+
+import (
+	"crypto"
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/cdnsd/internal/config"
+	"github.com/blinklabs-io/cdnsd/internal/state"
+	"github.com/miekg/dns"
+)
+
+func TestDefaultDNSSECTrustAnchors(t *testing.T) {
+	cfg := *config.GetConfig()
+	cfg.Dns.DNSSEC.Enabled = true
+
+	resolver, err := NewResolver(&cfg)
+	if err != nil {
+		t.Fatalf("NewResolver() error = %v", err)
+	}
+	anchors := resolver.configuredTrustAnchors(".")
+	if len(anchors) == 0 {
+		t.Fatal("got no root anchors")
+	}
+	for _, anchor := range anchors {
+		if _, ok := anchor.(*dns.DS); !ok {
+			t.Fatalf("root anchor has type %T, want *dns.DS", anchor)
+		}
+	}
+}
+
+func TestLoadTrustAnchorsRejectsOtherRecordTypes(t *testing.T) {
+	cfg := *config.GetConfig()
+	cfg.Dns.DNSSEC.Enabled = true
+	cfg.Dns.DNSSEC.TrustAnchors = ". 300 IN A 192.0.2.1"
+
+	_, err := NewResolver(&cfg)
+	if err == nil || !strings.Contains(err.Error(), "unsupported record type") {
+		t.Fatalf("NewResolver() error = %v, want unsupported type", err)
+	}
+}
+
+func TestLoadTrustAnchorsRejectsUnsupportedAlgorithms(t *testing.T) {
+	cfg := *config.GetConfig()
+	cfg.Dns.DNSSEC.Enabled = true
+	cfg.Dns.DNSSEC.TrustAnchors = strings.Join(
+		[]string{
+			". 300 IN DS 12345 5 2 " +
+				strings.Repeat("00", 32),
+			"",
+		},
+		"\n",
+	)
+
+	_, err := NewResolver(&cfg)
+	if err == nil ||
+		!strings.Contains(err.Error(), "unsupported DS trust anchor") {
+		t.Fatalf("NewResolver() error = %v, want unsupported anchor", err)
+	}
+}
+
+func TestDNSSECQuerySetsDOAndCD(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.", dns.TypeA)
+	got := dnssecQuery(msg)
+
+	if got.IsEdns0() == nil || !got.IsEdns0().Do() {
+		t.Fatal("dnssecQuery() did not set the EDNS DO bit")
+	}
+	if !got.CheckingDisabled {
+		t.Fatal("dnssecQuery() did not set CD for local validation")
+	}
+	if msg.IsEdns0() != nil || msg.CheckingDisabled {
+		t.Fatal("dnssecQuery() mutated the caller's message")
+	}
+}
+
+func TestDNSSECSecurityFilters(t *testing.T) {
+	key, signer := newTestDNSSECKey(t, "test.")
+	a := &dns.A{
+		Hdr: dns.RR_Header{
+			Name:   "outside.",
+			Rrtype: dns.TypeA,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		A: net.ParseIP("192.0.2.1"),
+	}
+	rrset := []dns.RR{a}
+	sig := signTestRRset(t, "test.", key, signer, rrset)
+	if err := verifyRRSet(
+		rrset,
+		[]*dns.RRSIG{sig},
+		[]*dns.DNSKEY{key},
+	); !errors.Is(err, errNoSignature) {
+		t.Fatalf("verifyRRSet() error = %v, want no signature", err)
+	}
+	signedA := &dns.A{
+		Hdr: dns.RR_Header{
+			Name:   "www.test.",
+			Rrtype: dns.TypeA,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		A: net.ParseIP("192.0.2.2"),
+	}
+	signedRRset := []dns.RR{signedA}
+	signedSig := signTestRRset(t, "test.", key, signer, signedRRset)
+	signedA.Hdr.Ttl = 3600
+	signedSig.Hdr.Ttl = 3600
+	if err := verifyRRSet(
+		signedRRset,
+		[]*dns.RRSIG{signedSig},
+		[]*dns.DNSKEY{key},
+	); err != nil {
+		t.Fatalf("verifyRRSet() with inflated TTL error = %v", err)
+	}
+	if signedA.Hdr.Ttl != 300 || signedSig.Hdr.Ttl != 300 {
+		t.Fatalf(
+			"validated TTLs = %d, %d; want 300",
+			signedA.Hdr.Ttl,
+			signedSig.Hdr.Ttl,
+		)
+	}
+
+	revoked := *key
+	revoked.Flags |= dns.REVOKE
+	unsupported := *key
+	unsupported.Algorithm = dns.DSA
+	active := activeDNSSECKeys([]*dns.DNSKEY{
+		key,
+		&revoked,
+		&unsupported,
+	})
+	if len(active) != 1 || active[0] != key {
+		t.Fatalf("activeDNSSECKeys() = %v, want only active key", active)
+	}
+	if !supportedDNSSECAlgorithm(dns.RSASHA1) ||
+		!supportedDNSSECAlgorithm(dns.RSASHA1NSEC3SHA1) {
+		t.Fatal("legacy SHA-1 signature validation is not supported")
+	}
+	if supportedDSAlgorithm(dns.RSASHA1) ||
+		supportedDSAlgorithm(dns.RSASHA1NSEC3SHA1) {
+		t.Fatal("deprecated SHA-1 DS algorithm is supported")
+	}
+	if !supportedDSDigest(dns.SHA1) {
+		t.Fatal("legacy SHA-1 DS digest validation is not supported")
+	}
+	if supportedDSDigest(dns.SHA512) {
+		t.Fatal("non-standard SHA-512 DS digest is supported")
+	}
+	tooExpensive := testNSEC3(
+		"name.test.",
+		"test.",
+		0,
+		nil,
+	)
+	tooExpensive.Iterations = 501
+	if validNSEC3(tooExpensive) {
+		t.Fatal("NSEC3 record above iteration limit is supported")
+	}
+}
+
+func TestValidatingQuerySetsAuthenticatedData(t *testing.T) {
+	zone := "secure.test."
+	key, signer := newTestDNSSECKey(t, zone)
+	anchor := testDS(t, key)
+	var sawDO atomic.Bool
+
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, req *dns.Msg) {
+		if opt := req.IsEdns0(); opt != nil && opt.Do() {
+			sawDO.Store(true)
+		}
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Authoritative = true
+		switch req.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			rrset := []dns.RR{key}
+			resp.Answer = append(resp.Answer, rrset...)
+			resp.Answer = append(
+				resp.Answer,
+				signTestRRset(t, zone, key, signer, rrset),
+			)
+		case dns.TypeA:
+			a := &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   zone,
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    300,
+				},
+				A: net.ParseIP("192.0.2.10"),
+			}
+			rrset := []dns.RR{a}
+			resp.Answer = append(resp.Answer, rrset...)
+			resp.Answer = append(
+				resp.Answer,
+				signTestRRset(t, zone, key, signer, rrset),
+			)
+		}
+		if err := w.WriteMsg(resp); err != nil {
+			t.Errorf("WriteMsg() error = %v", err)
+		}
+	})
+	ip, port := startTestDNSServer(t, "127.0.0.1:0", handler)
+
+	resolver := &Resolver{dnssecEnabled: true}
+	ctx := newResolutionContext()
+	ctx.validation = &dnssecValidation{
+		zone:    zone,
+		anchors: []dns.RR{anchor},
+	}
+	msg := new(dns.Msg)
+	msg.SetQuestion(zone, dns.TypeA)
+	msg.SetEdns0(1232, true)
+	resp, err := resolver.queryMultipleNameserversWithPort(
+		msg,
+		map[string][]net.IP{"ns.secure.test.": {ip}},
+		false,
+		ctx,
+		port,
+	)
+	if err != nil {
+		t.Fatalf("queryMultipleNameserversWithPort() error = %v", err)
+	}
+	if !resp.AuthenticatedData {
+		t.Fatal("validated response did not have the AD bit")
+	}
+	if !sawDO.Load() {
+		t.Fatal("authoritative server did not receive the DO bit")
+	}
+}
+
+func TestValidatingQueryRejectsBogusAnswer(t *testing.T) {
+	zone := "bogus.test."
+	key, signer := newTestDNSSECKey(t, zone)
+	anchor := testDS(t, key)
+
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, req *dns.Msg) {
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Authoritative = true
+		switch req.Question[0].Qtype {
+		case dns.TypeDNSKEY:
+			rrset := []dns.RR{key}
+			resp.Answer = append(resp.Answer, rrset...)
+			resp.Answer = append(
+				resp.Answer,
+				signTestRRset(t, zone, key, signer, rrset),
+			)
+		case dns.TypeA:
+			a := &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   zone,
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    300,
+				},
+				A: net.ParseIP("192.0.2.20"),
+			}
+			// The answer deliberately has no RRSIG.
+			resp.Answer = append(resp.Answer, a)
+		}
+		_ = w.WriteMsg(resp)
+	})
+	ip, port := startTestDNSServer(t, "127.0.0.1:0", handler)
+
+	resolver := &Resolver{dnssecEnabled: true}
+	ctx := newResolutionContext()
+	ctx.validation = &dnssecValidation{
+		zone:    zone,
+		anchors: []dns.RR{anchor},
+	}
+	msg := new(dns.Msg)
+	msg.SetQuestion(zone, dns.TypeA)
+	_, err := resolver.queryMultipleNameserversWithPort(
+		msg,
+		map[string][]net.IP{"ns.bogus.test.": {ip}},
+		false,
+		ctx,
+		port,
+	)
+	if err == nil || !strings.Contains(err.Error(), errDNSSECBogus.Error()) {
+		t.Fatalf("query error = %v, want DNSSEC validation failure", err)
+	}
+}
+
+func TestValidationCoversAuthoritySection(t *testing.T) {
+	zone := "secure.test."
+	key, signer := newTestDNSSECKey(t, zone)
+	query := new(dns.Msg)
+	query.SetQuestion("www."+zone, dns.TypeA)
+	answer := &dns.A{
+		Hdr: dns.RR_Header{
+			Name:   "www." + zone,
+			Rrtype: dns.TypeA,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		A: net.ParseIP("192.0.2.10"),
+	}
+	ns := &dns.NS{
+		Hdr: dns.RR_Header{
+			Name:   zone,
+			Rrtype: dns.TypeNS,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		Ns: "ns." + zone,
+	}
+	resp := new(dns.Msg)
+	resp.SetReply(query)
+	resp.Answer = []dns.RR{
+		answer,
+		signTestRRset(
+			t,
+			zone,
+			key,
+			signer,
+			[]dns.RR{answer},
+		),
+	}
+	resp.Ns = []dns.RR{ns}
+	validation := &dnssecValidation{
+		zone: zone,
+		keys: []*dns.DNSKEY{key},
+	}
+
+	if valid, err := (&Resolver{dnssecEnabled: true}).
+		validateFinalResponse(query, resp, validation); err == nil || valid {
+		t.Fatalf(
+			"validateFinalResponse() = %v, %v; want unsigned authority rejected",
+			valid,
+			err,
+		)
+	}
+
+	resp.Ns = append(
+		resp.Ns,
+		signTestRRset(t, zone, key, signer, []dns.RR{ns}),
+	)
+	if valid, err := (&Resolver{dnssecEnabled: true}).
+		validateFinalResponse(query, resp, validation); err != nil || !valid {
+		t.Fatalf(
+			"validateFinalResponse() = %v, %v; want fully signed response",
+			valid,
+			err,
+		)
+	}
+}
+
+func TestValidationForSignedDelegation(t *testing.T) {
+	parentZone := "test."
+	childZone := "child.test."
+	parentKey, parentSigner := newTestDNSSECKey(t, parentZone)
+	childKey, _ := newTestDNSSECKey(t, childZone)
+	childDS := testDS(t, childKey)
+	dsRRset := []dns.RR{childDS}
+
+	resp := new(dns.Msg)
+	resp.Ns = append(resp.Ns,
+		&dns.NS{
+			Hdr: dns.RR_Header{
+				Name:   childZone,
+				Rrtype: dns.TypeNS,
+				Class:  dns.ClassINET,
+				Ttl:    300,
+			},
+			Ns: "ns.child.test.",
+		},
+		childDS,
+		signTestRRset(
+			t,
+			parentZone,
+			parentKey,
+			parentSigner,
+			dsRRset,
+		),
+	)
+
+	resolver := &Resolver{dnssecEnabled: true}
+	got, err := resolver.validationForReferral(
+		resp,
+		&dnssecValidation{
+			zone: parentZone,
+			keys: []*dns.DNSKEY{parentKey},
+		},
+		childZone,
+	)
+	if err != nil {
+		t.Fatalf("validationForReferral() error = %v", err)
+	}
+	if got.zone != childZone || got.insecure || len(got.anchors) != 1 {
+		t.Fatalf("child validation = %#v", got)
+	}
+}
+
+func TestValidationForProvenUnsignedDelegation(t *testing.T) {
+	parentZone := "test."
+	childZone := "unsigned.test."
+	parentKey, parentSigner := newTestDNSSECKey(t, parentZone)
+	nsec := &dns.NSEC{
+		Hdr: dns.RR_Header{
+			Name:   childZone,
+			Rrtype: dns.TypeNSEC,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		NextDomain: "unsigned0.test.",
+		TypeBitMap: []uint16{dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC},
+	}
+	nsecRRset := []dns.RR{nsec}
+
+	resp := new(dns.Msg)
+	resp.Ns = append(resp.Ns,
+		&dns.NS{
+			Hdr: dns.RR_Header{
+				Name:   childZone,
+				Rrtype: dns.TypeNS,
+				Class:  dns.ClassINET,
+				Ttl:    300,
+			},
+			Ns: "ns.unsigned.test.",
+		},
+		nsec,
+		signTestRRset(
+			t,
+			parentZone,
+			parentKey,
+			parentSigner,
+			nsecRRset,
+		),
+	)
+
+	resolver := &Resolver{dnssecEnabled: true}
+	got, err := resolver.validationForReferral(
+		resp,
+		&dnssecValidation{
+			zone: parentZone,
+			keys: []*dns.DNSKEY{parentKey},
+		},
+		childZone,
+	)
+	if err != nil {
+		t.Fatalf("validationForReferral() error = %v", err)
+	}
+	if got.zone != childZone || !got.insecure {
+		t.Fatalf("child validation = %#v, want insecure", got)
+	}
+}
+
+func TestValidationForNSEC3OptOutDelegation(t *testing.T) {
+	parentZone := "test."
+	childZone := "deep.unsigned.test."
+	parentKey, parentSigner := newTestDNSSECKey(t, parentZone)
+	optOut := testNSEC3(
+		"cover.test.",
+		parentZone,
+		1,
+		nil,
+	)
+	closest := testNSEC3(
+		parentZone,
+		parentZone,
+		0,
+		[]uint16{dns.TypeNS, dns.TypeSOA},
+	)
+	resp := new(dns.Msg)
+	resp.Ns = append(
+		resp.Ns,
+		&dns.NS{
+			Hdr: dns.RR_Header{
+				Name:   childZone,
+				Rrtype: dns.TypeNS,
+				Class:  dns.ClassINET,
+				Ttl:    300,
+			},
+			Ns: "ns.deep.unsigned.test.",
+		},
+		optOut,
+		signTestRRset(
+			t,
+			parentZone,
+			parentKey,
+			parentSigner,
+			[]dns.RR{optOut},
+		),
+		closest,
+		signTestRRset(
+			t,
+			parentZone,
+			parentKey,
+			parentSigner,
+			[]dns.RR{closest},
+		),
+	)
+
+	got, err := (&Resolver{dnssecEnabled: true}).validationForReferral(
+		resp,
+		&dnssecValidation{
+			zone: parentZone,
+			keys: []*dns.DNSKEY{parentKey},
+		},
+		childZone,
+	)
+	if err != nil {
+		t.Fatalf("validationForReferral() error = %v", err)
+	}
+	if got.zone != childZone || !got.insecure {
+		t.Fatalf("child validation = %#v, want insecure", got)
+	}
+}
+
+func TestValidationForReferralRejectsUnrelatedOwners(t *testing.T) {
+	tests := map[string][]dns.RR{
+		"multiple NS owners": {
+			&dns.NS{
+				Hdr: dns.RR_Header{
+					Name:   "child.test.",
+					Rrtype: dns.TypeNS,
+				},
+			},
+			&dns.NS{
+				Hdr: dns.RR_Header{
+					Name:   "other.test.",
+					Rrtype: dns.TypeNS,
+				},
+			},
+		},
+		"outside parent": {
+			&dns.NS{
+				Hdr: dns.RR_Header{
+					Name:   "unrelated.",
+					Rrtype: dns.TypeNS,
+				},
+			},
+		},
+		"outside query": {
+			&dns.NS{
+				Hdr: dns.RR_Header{
+					Name:   "sibling.test.",
+					Rrtype: dns.TypeNS,
+				},
+			},
+		},
+	}
+	for name, authority := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := (&Resolver{dnssecEnabled: true}).
+				validationForReferral(
+					&dns.Msg{Ns: authority},
+					&dnssecValidation{
+						zone:     "test.",
+						insecure: true,
+					},
+					"host.child.test.",
+				)
+			if !errors.Is(err, errDNSSECBogus) {
+				t.Fatalf("validationForReferral() error = %v, want bogus", err)
+			}
+		})
+	}
+}
+
+func TestValidateAuthenticatedNegativeResponses(t *testing.T) {
+	zone := "secure.test."
+	key, signer := newTestDNSSECKey(t, zone)
+	soa := &dns.SOA{
+		Hdr: dns.RR_Header{
+			Name:   zone,
+			Rrtype: dns.TypeSOA,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		Ns:      "ns.secure.test.",
+		Mbox:    "hostmaster.secure.test.",
+		Serial:  1,
+		Refresh: 3600,
+		Retry:   900,
+		Expire:  604800,
+		Minttl:  300,
+	}
+
+	t.Run("NODATA", func(t *testing.T) {
+		name := "present.secure.test."
+		nsec := &dns.NSEC{
+			Hdr: dns.RR_Header{
+				Name:   name,
+				Rrtype: dns.TypeNSEC,
+				Class:  dns.ClassINET,
+				Ttl:    300,
+			},
+			NextDomain: "z.secure.test.",
+			TypeBitMap: []uint16{
+				dns.TypeA,
+				dns.TypeRRSIG,
+				dns.TypeNSEC,
+			},
+		}
+		resp := signedNegativeResponse(
+			t,
+			dns.RcodeSuccess,
+			zone,
+			key,
+			signer,
+			soa,
+			nsec,
+		)
+		query := new(dns.Msg)
+		query.SetQuestion(name, dns.TypeAAAA)
+		valid, err := (&Resolver{}).validateFinalResponse(
+			query,
+			resp,
+			&dnssecValidation{
+				zone: zone,
+				keys: []*dns.DNSKEY{key},
+			},
+		)
+		if err != nil || !valid {
+			t.Fatalf(
+				"validateFinalResponse() = %v, %v; want true, nil",
+				valid,
+				err,
+			)
+		}
+	})
+
+	t.Run("NXDOMAIN", func(t *testing.T) {
+		nsec := &dns.NSEC{
+			Hdr: dns.RR_Header{
+				Name:   zone,
+				Rrtype: dns.TypeNSEC,
+				Class:  dns.ClassINET,
+				Ttl:    300,
+			},
+			NextDomain: "z.secure.test.",
+			TypeBitMap: []uint16{
+				dns.TypeNS,
+				dns.TypeSOA,
+				dns.TypeRRSIG,
+				dns.TypeNSEC,
+			},
+		}
+		resp := signedNegativeResponse(
+			t,
+			dns.RcodeNameError,
+			zone,
+			key,
+			signer,
+			soa,
+			nsec,
+		)
+		query := new(dns.Msg)
+		query.SetQuestion("missing.secure.test.", dns.TypeA)
+		valid, err := (&Resolver{}).validateFinalResponse(
+			query,
+			resp,
+			&dnssecValidation{
+				zone: zone,
+				keys: []*dns.DNSKEY{key},
+			},
+		)
+		if err != nil || !valid {
+			t.Fatalf(
+				"validateFinalResponse() = %v, %v; want true, nil",
+				valid,
+				err,
+			)
+		}
+	})
+
+	t.Run("NSEC empty non-terminal", func(t *testing.T) {
+		name := "empty.secure.test."
+		nsec := &dns.NSEC{
+			Hdr: dns.RR_Header{
+				Name:   "a.secure.test.",
+				Rrtype: dns.TypeNSEC,
+				Class:  dns.ClassINET,
+				Ttl:    300,
+			},
+			NextDomain: "child.empty.secure.test.",
+			TypeBitMap: []uint16{dns.TypeRRSIG, dns.TypeNSEC},
+		}
+		assertValidNegativeResponse(
+			t,
+			zone,
+			key,
+			signer,
+			soa,
+			dns.RcodeSuccess,
+			name,
+			dns.TypeAAAA,
+			nsec,
+		)
+	})
+
+	t.Run("NSEC wildcard NODATA", func(t *testing.T) {
+		name := "host.wild.secure.test."
+		cover := &dns.NSEC{
+			Hdr: dns.RR_Header{
+				Name:   zone,
+				Rrtype: dns.TypeNSEC,
+				Class:  dns.ClassINET,
+				Ttl:    300,
+			},
+			NextDomain: "z.secure.test.",
+			TypeBitMap: []uint16{
+				dns.TypeNS,
+				dns.TypeSOA,
+				dns.TypeRRSIG,
+				dns.TypeNSEC,
+			},
+		}
+		wildcard := &dns.NSEC{
+			Hdr: dns.RR_Header{
+				Name:   "*.wild.secure.test.",
+				Rrtype: dns.TypeNSEC,
+				Class:  dns.ClassINET,
+				Ttl:    300,
+			},
+			NextDomain: "z.wild.secure.test.",
+			TypeBitMap: []uint16{
+				dns.TypeA,
+				dns.TypeRRSIG,
+				dns.TypeNSEC,
+			},
+		}
+		assertValidNegativeResponse(
+			t,
+			zone,
+			key,
+			signer,
+			soa,
+			dns.RcodeSuccess,
+			name,
+			dns.TypeAAAA,
+			cover,
+			wildcard,
+		)
+	})
+
+	t.Run("NSEC3 NODATA", func(t *testing.T) {
+		name := "present.secure.test."
+		nsec3 := testNSEC3(
+			name,
+			zone,
+			0,
+			[]uint16{dns.TypeA},
+		)
+		assertValidNegativeResponse(
+			t,
+			zone,
+			key,
+			signer,
+			soa,
+			dns.RcodeSuccess,
+			name,
+			dns.TypeAAAA,
+			nsec3,
+		)
+	})
+
+	t.Run("NSEC3 NXDOMAIN", func(t *testing.T) {
+		name := "missing.secure.test."
+		closest := testNSEC3(
+			zone,
+			zone,
+			0,
+			[]uint16{dns.TypeNS, dns.TypeSOA},
+		)
+		if !provesNXDOMAIN(name, []dns.RR{closest}) {
+			t.Fatal("provesNXDOMAIN() rejected closest-encloser proof")
+		}
+		assertValidNegativeResponse(
+			t,
+			zone,
+			key,
+			signer,
+			soa,
+			dns.RcodeNameError,
+			name,
+			dns.TypeA,
+			closest,
+		)
+	})
+
+	t.Run("NSEC3 wildcard NODATA", func(t *testing.T) {
+		name := "host.wild.secure.test."
+		closestName := "wild.secure.test."
+		closest := testNSEC3(
+			closestName,
+			zone,
+			0,
+			nil,
+		)
+		wildcard := testNSEC3(
+			wildcardName(closestName),
+			zone,
+			0,
+			[]uint16{dns.TypeA},
+		)
+		assertValidNegativeResponse(
+			t,
+			zone,
+			key,
+			signer,
+			soa,
+			dns.RcodeSuccess,
+			name,
+			dns.TypeAAAA,
+			closest,
+			wildcard,
+		)
+	})
+
+	t.Run("NSEC3 opt-out empty non-terminal", func(t *testing.T) {
+		name := "empty.delegation.secure.test."
+		closest := testNSEC3(
+			zone,
+			zone,
+			1,
+			[]uint16{dns.TypeNS, dns.TypeSOA},
+		)
+		assertValidNegativeResponse(
+			t,
+			zone,
+			key,
+			signer,
+			soa,
+			dns.RcodeSuccess,
+			name,
+			dns.TypeAAAA,
+			closest,
+		)
+	})
+
+	t.Run("NSEC3 signed but non-proving", func(t *testing.T) {
+		name := "missing.secure.test."
+		nonProof := testNSEC3(name, zone, 0, nil)
+		resp := signedNegativeResponse(
+			t,
+			dns.RcodeNameError,
+			zone,
+			key,
+			signer,
+			soa,
+			nonProof,
+		)
+		query := new(dns.Msg)
+		query.SetQuestion(name, dns.TypeA)
+		valid, err := (&Resolver{}).validateFinalResponse(
+			query,
+			resp,
+			&dnssecValidation{
+				zone: zone,
+				keys: []*dns.DNSKEY{key},
+			},
+		)
+		if err == nil || valid {
+			t.Fatalf(
+				"validateFinalResponse() = %v, %v; want false, error",
+				valid,
+				err,
+			)
+		}
+	})
+}
+
+func TestOnChainDSBecomesTrustAnchor(t *testing.T) {
+	loadIsolatedTestState(t)
+
+	key, _ := newTestDNSSECKey(t, "chainroot.")
+	ds := testDS(t, key)
+	if err := state.GetState().UpdateHandshakeDomain(
+		"chainroot.",
+		[]state.DomainRecord{
+			{
+				Lhs:  "chainroot.",
+				Type: "DS",
+				Ttl:  300,
+				Rhs: fmt.Sprintf(
+					"%d %d %d %s",
+					ds.KeyTag,
+					ds.Algorithm,
+					ds.DigestType,
+					ds.Digest,
+				),
+			},
+		},
+	); err != nil {
+		t.Fatalf("UpdateHandshakeDomain() error = %v", err)
+	}
+
+	resolver := &Resolver{
+		dnssecEnabled: true,
+		trustAnchors:  make(map[string][]dns.RR),
+	}
+	anchors, err := resolver.trustAnchorsForZone("chainroot.")
+	if err != nil {
+		t.Fatalf("trustAnchorsForZone() error = %v", err)
+	}
+	if len(anchors) != 1 {
+		t.Fatalf("anchor count = %d, want 1", len(anchors))
+	}
+	got, ok := anchors[0].(*dns.DS)
+	if !ok || got.KeyTag != ds.KeyTag ||
+		!strings.EqualFold(got.Digest, ds.Digest) {
+		t.Fatalf("on-chain anchor = %#v, want %s", anchors[0], ds)
+	}
+
+	// A same-named Cardano delegation takes precedence and must not
+	// inherit the Handshake anchor from a different root.
+	if err := state.GetState().UpdateDomain(
+		"chainroot.",
+		[]state.DomainRecord{
+			{
+				Lhs:  "chainroot.",
+				Type: "NS",
+				Ttl:  300,
+				Rhs:  "ns.chainroot.",
+			},
+		},
+	); err != nil {
+		t.Fatalf("UpdateDomain() error = %v", err)
+	}
+	anchors, err = resolver.trustAnchorsForZone("chainroot.")
+	if err != nil {
+		t.Fatalf("trustAnchorsForZone() error = %v", err)
+	}
+	if len(anchors) != 0 {
+		t.Fatalf(
+			"Cardano delegation inherited %d Handshake anchors",
+			len(anchors),
+		)
+	}
+}
+
+func loadIsolatedTestState(t *testing.T) {
+	t.Helper()
+	cfg := config.GetConfig()
+	oldDirectory := cfg.State.Directory
+	wasLoaded := stateIsLoaded()
+	if err := state.GetState().Close(); err != nil {
+		t.Fatalf("state.Close() error = %v", err)
+	}
+	cfg.State.Directory = t.TempDir()
+	if err := state.GetState().Load(); err != nil {
+		t.Fatalf("state.Load() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := state.GetState().Close(); err != nil {
+			t.Errorf("state.Close() error = %v", err)
+		}
+		cfg.State.Directory = oldDirectory
+		if wasLoaded {
+			if err := state.GetState().Load(); err != nil {
+				t.Errorf("restore state.Load() error = %v", err)
+			}
+		}
+	})
+}
+
+func TestLocalAuthenticatedDenialResponses(t *testing.T) {
+	loadIsolatedTestState(t)
+	zone := "ada."
+	key, signer := newTestDNSSECKey(t, zone)
+	soa := generateSyntheticSOA(zone)
+	nsec := &dns.NSEC{
+		Hdr: dns.RR_Header{
+			Name:   zone,
+			Rrtype: dns.TypeNSEC,
+			Class:  dns.ClassINET,
+			Ttl:    soa.Hdr.Ttl,
+		},
+		NextDomain: "z.ada.",
+		TypeBitMap: []uint16{
+			dns.TypeSOA,
+			dns.TypeRRSIG,
+			dns.TypeNSEC,
+		},
+	}
+	records := []state.DomainRecord{
+		testStateRecord(t, soa),
+		testStateRecord(t, nsec),
+		testStateRecord(
+			t,
+			signTestRRset(
+				t,
+				zone,
+				key,
+				signer,
+				[]dns.RR{nsec},
+			),
+		),
+		testStateRecord(
+			t,
+			signTestRRset(
+				t,
+				zone,
+				key,
+				signer,
+				[]dns.RR{soa},
+			),
+		),
+	}
+	if err := state.GetState().UpdateDomain(zone, records); err != nil {
+		t.Fatalf("UpdateDomain() error = %v", err)
+	}
+
+	resolver := &Resolver{}
+	req := new(dns.Msg)
+	req.SetQuestion("missing.ada.", dns.TypeA)
+	req.SetEdns0(1232, true)
+	writer := new(captureResponseWriter)
+	resolver.handleQuery(writer, req)
+	if writer.msg == nil {
+		t.Fatal("handleQuery() wrote no NXDOMAIN response")
+	}
+	if writer.msg.Rcode != dns.RcodeNameError {
+		t.Fatalf("response = %v, want NXDOMAIN", writer.msg)
+	}
+	if !writer.msg.Authoritative {
+		t.Fatal("local NXDOMAIN response is not authoritative")
+	}
+	if len(rrsetFrom(writer.msg.Ns, zone, dns.TypeSOA)) != 1 ||
+		len(signaturesFor(writer.msg.Ns, zone, dns.TypeSOA)) != 1 ||
+		len(rrsetFrom(writer.msg.Ns, zone, dns.TypeNSEC)) != 1 ||
+		len(signaturesFor(writer.msg.Ns, zone, dns.TypeNSEC)) != 1 {
+		t.Fatalf("authenticated denial authority = %v", writer.msg.Ns)
+	}
+	valid, err := resolver.validateFinalResponse(
+		req,
+		writer.msg,
+		&dnssecValidation{
+			zone: zone,
+			keys: []*dns.DNSKEY{key},
+		},
+	)
+	if err != nil || !valid {
+		t.Fatalf(
+			"validateFinalResponse(local denial) = %v, %v",
+			valid,
+			err,
+		)
+	}
+
+	req = new(dns.Msg)
+	req.SetQuestion(zone, dns.TypeSOA)
+	req.SetEdns0(1232, true)
+	writer = new(captureResponseWriter)
+	resolver.handleQuery(writer, req)
+	if writer.msg == nil {
+		t.Fatal("handleQuery() wrote no SOA response")
+	}
+	if len(rrsetFrom(writer.msg.Answer, zone, dns.TypeSOA)) != 1 ||
+		len(signaturesFor(writer.msg.Answer, zone, dns.TypeSOA)) != 1 {
+		t.Fatalf("signed stored SOA answer = %v", writer.msg.Answer)
+	}
+	valid, err = resolver.validateFinalResponse(
+		req,
+		writer.msg,
+		&dnssecValidation{
+			zone: zone,
+			keys: []*dns.DNSKEY{key},
+		},
+	)
+	if err != nil || !valid {
+		t.Fatalf(
+			"validateFinalResponse(local SOA) = %v, %v",
+			valid,
+			err,
+		)
+	}
+
+	if err := state.GetState().UpdateDomain(zone, nil); err != nil {
+		t.Fatalf("clear UpdateDomain() error = %v", err)
+	}
+	req = new(dns.Msg)
+	req.SetQuestion("unsigned.ada.", dns.TypeA)
+	req.SetEdns0(1232, true)
+	writer = new(captureResponseWriter)
+	resolver.handleQuery(writer, req)
+	if writer.msg == nil {
+		t.Fatal("handleQuery() wrote no unsigned response")
+	}
+	if len(writer.msg.Ns) != 1 ||
+		writer.msg.Ns[0].Header().Rrtype != dns.TypeSOA {
+		t.Fatalf("unsigned authority = %v, want only SOA", writer.msg.Ns)
+	}
+}
+
+func TestLocalDNSSECRecordsDoNotMixRoots(t *testing.T) {
+	loadIsolatedTestState(t)
+	zone := "hns."
+	handshakeNSEC := &dns.NSEC{
+		Hdr: dns.RR_Header{
+			Name:   zone,
+			Rrtype: dns.TypeNSEC,
+			Class:  dns.ClassINET,
+		},
+		NextDomain: "z.hns.",
+		TypeBitMap: []uint16{dns.TypeNS, dns.TypeNSEC},
+	}
+	cardanoNSEC := &dns.NSEC{
+		Hdr: dns.RR_Header{
+			Name:   "poison.hns.",
+			Rrtype: dns.TypeNSEC,
+			Class:  dns.ClassINET,
+		},
+		NextDomain: "z.hns.",
+		TypeBitMap: []uint16{dns.TypeNSEC},
+	}
+	if err := state.GetState().UpdateHandshakeDomain(
+		zone,
+		[]state.DomainRecord{
+			{
+				Lhs:  zone,
+				Type: "NS",
+				Rhs:  "ns.hns.",
+			},
+			testStateRecord(t, handshakeNSEC),
+		},
+	); err != nil {
+		t.Fatalf("UpdateHandshakeDomain() error = %v", err)
+	}
+	if err := state.GetState().UpdateDomain(
+		"poison.hns.",
+		[]state.DomainRecord{testStateRecord(t, cardanoNSEC)},
+	); err != nil {
+		t.Fatalf("UpdateDomain() error = %v", err)
+	}
+
+	fromHandshake, err := localZoneUsesHandshake(zone)
+	if err != nil || !fromHandshake {
+		t.Fatalf(
+			"localZoneUsesHandshake() = %v, %v; want Handshake",
+			fromHandshake,
+			err,
+		)
+	}
+	records, err := lookupLocalZoneDNSSECRecords(zone, fromHandshake)
+	if err != nil {
+		t.Fatalf("lookupLocalZoneDNSSECRecords() error = %v", err)
+	}
+	if len(records) != 1 ||
+		canonicalDNSName(records[0].Header().Name) != zone {
+		t.Fatalf("local DNSSEC records crossed roots: %v", records)
+	}
+}
+
+func TestCopyResponseDNSSECVisibility(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("secure.test.", dns.TypeA)
+	src := new(dns.Msg)
+	src.SetReply(req)
+	src.AuthenticatedData = true
+	src.Answer = []dns.RR{
+		&dns.A{
+			Hdr: dns.RR_Header{
+				Name:   "secure.test.",
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+			},
+			A: net.ParseIP("192.0.2.30"),
+		},
+		&dns.RRSIG{
+			Hdr: dns.RR_Header{
+				Name:   "secure.test.",
+				Rrtype: dns.TypeRRSIG,
+				Class:  dns.ClassINET,
+			},
+			TypeCovered: dns.TypeA,
+		},
+	}
+	dest := new(dns.Msg)
+	copyResponse(req, src, dest)
+	if dest.AuthenticatedData {
+		t.Fatal("copyResponse() preserved AD without an AD or DO request")
+	}
+	if len(dest.Answer) != 1 {
+		t.Fatalf("answer count without DO = %d, want 1", len(dest.Answer))
+	}
+
+	req.AuthenticatedData = true
+	dest = new(dns.Msg)
+	copyResponse(req, src, dest)
+	if !dest.AuthenticatedData {
+		t.Fatal("copyResponse() did not preserve requested AD without DO")
+	}
+	if len(dest.Answer) != 1 {
+		t.Fatalf("answer count with AD request = %d, want 1", len(dest.Answer))
+	}
+
+	req.SetEdns0(1232, true)
+	dest = new(dns.Msg)
+	copyResponse(req, src, dest)
+	if !dest.AuthenticatedData {
+		t.Fatal("copyResponse() did not preserve AD with DO")
+	}
+	if len(dest.Answer) != 2 {
+		t.Fatalf("answer count with DO = %d, want 2", len(dest.Answer))
+	}
+
+	records := slices.Clone(src.Answer)
+	if len(records) != 2 {
+		t.Fatalf("copied source records = %v, want two records", records)
+	}
+	filtered := filterDNSSECRecords(records, dns.TypeA)
+	if len(filtered) != 1 ||
+		filtered[0].Header().Rrtype != dns.TypeA ||
+		records[1].Header().Rrtype != dns.TypeRRSIG {
+		t.Fatalf(
+			"filterDNSSECRecords() mutated input: records=%v filtered=%v",
+			records,
+			filtered,
+		)
+	}
+
+	filtered = filterDNSSECRecords(records[1:], dns.TypeRRSIG)
+	if len(filtered) != 1 ||
+		filtered[0].Header().Rrtype != dns.TypeRRSIG {
+		t.Fatalf("explicit RRSIG answer was filtered: %v", filtered)
+	}
+}
+
+func testDS(t *testing.T, key *dns.DNSKEY) *dns.DS {
+	t.Helper()
+	ds := key.ToDS(dns.SHA256)
+	if ds == nil {
+		t.Fatal("DNSKEY.ToDS() returned nil")
+	}
+	return ds
+}
+
+func testStateRecord(t *testing.T, rr dns.RR) state.DomainRecord {
+	t.Helper()
+	fields := strings.SplitN(rr.String(), "\t", 5)
+	if len(fields) != 5 {
+		t.Fatalf("unexpected RR presentation: %q", rr)
+	}
+	return state.DomainRecord{
+		Lhs:  fields[0],
+		Type: fields[3],
+		Rhs:  fields[4],
+	}
+}
+
+func testNSEC3(
+	name string,
+	zone string,
+	flags uint8,
+	types []uint16,
+) *dns.NSEC3 {
+	hash := dns.HashName(name, dns.SHA1, 0, "")
+	return &dns.NSEC3{
+		Hdr: dns.RR_Header{
+			Name:   hash + "." + dns.Fqdn(zone),
+			Rrtype: dns.TypeNSEC3,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		Hash:       dns.SHA1,
+		Flags:      flags,
+		NextDomain: hash,
+		TypeBitMap: types,
+	}
+}
+
+func assertValidNegativeResponse(
+	t *testing.T,
+	zone string,
+	key *dns.DNSKEY,
+	signer crypto.Signer,
+	soa *dns.SOA,
+	rcode int,
+	name string,
+	qtype uint16,
+	denials ...dns.RR,
+) {
+	t.Helper()
+	resp := signedNegativeResponse(
+		t,
+		rcode,
+		zone,
+		key,
+		signer,
+		soa,
+		denials...,
+	)
+	query := new(dns.Msg)
+	query.SetQuestion(name, qtype)
+	valid, err := (&Resolver{}).validateFinalResponse(
+		query,
+		resp,
+		&dnssecValidation{
+			zone: zone,
+			keys: []*dns.DNSKEY{key},
+		},
+	)
+	if err != nil || !valid {
+		t.Fatalf(
+			"validateFinalResponse() = %v, %v; want true, nil",
+			valid,
+			err,
+		)
+	}
+}
+
+func newTestDNSSECKey(
+	t *testing.T,
+	zone string,
+) (*dns.DNSKEY, crypto.Signer) {
+	t.Helper()
+	key := &dns.DNSKEY{
+		Hdr: dns.RR_Header{
+			Name:   dns.Fqdn(zone),
+			Rrtype: dns.TypeDNSKEY,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		Flags:     dns.ZONE | dns.SEP,
+		Protocol:  3,
+		Algorithm: dns.ED25519,
+	}
+	privateKey, err := key.Generate(256)
+	if err != nil {
+		t.Fatalf("DNSKEY.Generate() error = %v", err)
+	}
+	signer, ok := privateKey.(crypto.Signer)
+	if !ok {
+		t.Fatalf("private key has type %T, want crypto.Signer", privateKey)
+	}
+	return key, signer
+}
+
+func signTestRRset(
+	t *testing.T,
+	zone string,
+	key *dns.DNSKEY,
+	signer crypto.Signer,
+	rrset []dns.RR,
+) *dns.RRSIG {
+	t.Helper()
+	if len(rrset) == 0 {
+		t.Fatal("cannot sign empty RRset")
+	}
+	now := time.Now()
+	sig := &dns.RRSIG{
+		Hdr: dns.RR_Header{
+			Name:   rrset[0].Header().Name,
+			Rrtype: dns.TypeRRSIG,
+			Class:  rrset[0].Header().Class,
+			Ttl:    rrset[0].Header().Ttl,
+		},
+		TypeCovered: rrset[0].Header().Rrtype,
+		Algorithm:   key.Algorithm,
+		Labels:      uint8(dns.CountLabel(rrset[0].Header().Name)),
+		OrigTtl:     rrset[0].Header().Ttl,
+		Expiration:  uint32(now.Add(time.Hour).Unix()),
+		Inception:   uint32(now.Add(-time.Hour).Unix()),
+		KeyTag:      key.KeyTag(),
+		SignerName:  dns.Fqdn(zone),
+	}
+	if err := sig.Sign(signer, rrset); err != nil {
+		t.Fatalf("RRSIG.Sign(%s) error = %v", fmt.Sprint(rrset), err)
+	}
+	return sig
+}
+
+func signedNegativeResponse(
+	t *testing.T,
+	rcode int,
+	zone string,
+	key *dns.DNSKEY,
+	signer crypto.Signer,
+	soa *dns.SOA,
+	denials ...dns.RR,
+) *dns.Msg {
+	t.Helper()
+	soaRRset := []dns.RR{soa}
+	ret := &dns.Msg{
+		MsgHdr: dns.MsgHdr{
+			Response:      true,
+			Authoritative: true,
+			Rcode:         rcode,
+		},
+		Ns: []dns.RR{
+			soa,
+			signTestRRset(t, zone, key, signer, soaRRset),
+		},
+	}
+	type rrsetKey struct {
+		name   string
+		rrType uint16
+	}
+	rrsets := make(map[rrsetKey][]dns.RR)
+	for _, rr := range denials {
+		ret.Ns = append(ret.Ns, rr)
+		rrset := rrsetKey{
+			name:   canonicalDNSName(rr.Header().Name),
+			rrType: rr.Header().Rrtype,
+		}
+		rrsets[rrset] = append(rrsets[rrset], rr)
+	}
+	for _, rrset := range rrsets {
+		ret.Ns = append(
+			ret.Ns,
+			signTestRRset(t, zone, key, signer, rrset),
+		)
+	}
+	return ret
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -491,6 +491,64 @@ func (s *State) LookupRecords(
 	)
 }
 
+func (s *State) LookupRecordsInZone(
+	recordTypes []string,
+	zone string,
+) ([]DomainRecord, error) {
+	return s.lookupRecordsInZone(
+		recordTypes,
+		zone,
+		cardanoRecordKeyPrefix,
+	)
+}
+
+func (s *State) lookupRecordsInZone(
+	recordTypes []string,
+	zone string,
+	recordKeyPrefix string,
+) ([]DomainRecord, error) {
+	var ret []DomainRecord
+	zone = strings.ToLower(strings.Trim(zone, "."))
+	err := s.view(func(txn *badger.Txn) error {
+		for _, recordType := range recordTypes {
+			keyPrefix := fmt.Appendf(
+				nil,
+				"%s%s_",
+				recordKeyPrefix,
+				strings.ToUpper(recordType),
+			)
+			it := txn.NewIterator(badger.DefaultIteratorOptions)
+			defer it.Close()
+			for it.Seek(keyPrefix); it.ValidForPrefix(keyPrefix); it.Next() {
+				item := it.Item()
+				val, err := item.ValueCopy(nil)
+				if err != nil {
+					return err
+				}
+				var record DomainRecord
+				if err := gob.NewDecoder(bytes.NewReader(val)).
+					Decode(&record); err != nil {
+					return err
+				}
+				name := strings.ToLower(strings.Trim(record.Lhs, "."))
+				if zone != "" && name != zone &&
+					!strings.HasSuffix(name, "."+zone) {
+					continue
+				}
+				ret = append(ret, record)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(ret) == 0 {
+		return nil, nil
+	}
+	return ret, nil
+}
+
 func (s *State) lookupRecords(
 	recordTypes []string,
 	recordName string,
@@ -627,6 +685,17 @@ func (s *State) LookupHandshakeRecords(
 	return s.lookupRecords(
 		recordTypes,
 		recordName,
+		handshakeRecordKeyPrefix,
+	)
+}
+
+func (s *State) LookupHandshakeRecordsInZone(
+	recordTypes []string,
+	zone string,
+) ([]DomainRecord, error) {
+	return s.lookupRecordsInZone(
+		recordTypes,
+		zone,
 		handshakeRecordKeyPrefix,
 	)
 }


### PR DESCRIPTION
Closes #472 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add opt-in DNSSEC validation to recursive resolution with multi-root trust and strict glue handling. Validated answers set AD; bogus chains return SERVFAIL; only in-bailiwick glue is honored.

- **New Features**
  - DNSSEC validation: fetches DNSKEY/DS, verifies RRSIGs, and authenticates NSEC/NSEC3 for NXDOMAIN/NODATA and wildcard proofs; sets DO+CD on upstream queries and AD on validated replies; hides DNSSEC records when the client doesn’t set DO.
  - Multi-root trust: combines configured anchors with on-chain DS as trust anchors per zone (Cardano first, Handshake fallback), enabling independent DNSSEC islands.
  - Local answers: when requested with DO, returns matching RRSIGs and signed SOA/NSEC/NSEC3 denial proofs for Cardano/Handshake zones; uses stored SOA when present.
  - Referrals and glue: only accepts in-bailiwick glue; out-of-bailiwick NS addresses are resolved separately; requires signed DS RRsets or authenticated unsigned delegation (incl. NSEC3 opt‑out).

- **Migration**
  - DNSSEC is opt-in: set `dns.dnssec.enabled: true`.
  - Optional anchors via `dns.dnssec.trustAnchorsFile` or `dns.dnssec.trustAnchors` (zone-file `DS`/`DNSKEY`). Defaults include IANA KSK-2017 and KSK-2024.
  - On-chain `DS` records automatically act as trust anchors for their zones; no extra config needed.

<sup>Written for commit 7e5b11594446b5131b5be2bcdc31e70e816d09d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cdnsd/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in DNSSEC validation for recursive DNS resolution.
  - Validated responses include authenticated data; invalid signatures return `SERVFAIL`.
  - Supports authenticated negative responses and unsigned delegations.
  - Added configuration for enabling DNSSEC and supplying custom trust anchors.
  - Supports blockchain-authenticated DNSSEC trust anchors.

- **Documentation**
  - Documented DNSSEC behavior, configuration options, trust anchors, and multiple-root support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->