### PR TITLE
feat: automate DNSSEC root trust-anchor lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Resolver for Cardano-based second-level domains on Handshake top-level domains
 | `dns.dnssec.enabled`    | bool         | `DNSSEC_ENABLED`                  | Validate recursive DNSSEC chains (default: false) |
 | `dns.dnssec.trustAnchors` | string     | `DNSSEC_TRUST_ANCHORS`            | DS or DNSKEY trust anchors in zone-file format |
 | `dns.dnssec.trustAnchorsFile` | string | `DNSSEC_TRUST_ANCHORS_FILE`       | File containing DS or DNSKEY trust anchors |
+| `dns.dnssec.rootAnchorRefreshInterval` | duration | `DNSSEC_ROOT_ANCHOR_REFRESH_INTERVAL` | RFC 5011 root DNSKEY refresh interval (default: 24h) |
+| `dns.dnssec.rootAnchorHoldDown` | duration | `DNSSEC_ROOT_ANCHOR_HOLD_DOWN` | RFC 5011 add/remove hold-down (default: 720h) |
 | `debug.address`         | string       | `DEBUG_ADDRESS`                   | Address for debug HTTP server (default: localhost) |
 | `debug.port`            | uint         | `DEBUG_PORT`                      | Port for debug HTTP server |
 | `indexer.network`       | string       | `INDEXER_NETWORK`                 | Cardano network name (e.g. preprod, mainnet) |
@@ -113,6 +115,21 @@ The bundled trust-anchor set contains the IANA KSK-2017 and KSK-2024
 anchors. Supplying `trustAnchors` or `trustAnchorsFile` replaces that set.
 Each non-comment line must be a complete `DS` or `DNSKEY` record, and
 anchors for multiple zones may be listed together.
+
+When DNSSEC is enabled, the root anchor set is refreshed from an authenticated
+root DNSKEY response. New SEP keys remain `add_pending` until the configured
+RFC 5011 hold-down has elapsed; missing keys enter `remove_pending`, and a
+revoked key is removed immediately. The state is stored in `state.dir` and is
+loaded before the first refresh, so a restart during hold-down does not reset
+the timer. Failed, unsigned, or otherwise unauthenticated responses are
+discarded and cannot replace the last known-good set. Refresh transitions are
+logged and exposed through `dnssec_root_anchor_transition_total` and
+`dnssec_root_anchor_active`.
+
+The bundled anchors are the bootstrap. Operators should monitor the transition
+metric and logs during a rollover. For manual recovery, stop cdnsd, preserve a
+backup, remove the `dnssec_root_anchor_state` entry from the Badger state
+directory, and restart with a verified `trustAnchorsFile`.
 
 Cardano and Handshake records do not need to descend from the ICANN root.
 When an on-chain delegation contains a `DS` record, cdnsd uses that record

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"gopkg.in/yaml.v2"
@@ -47,9 +48,11 @@ type DnsConfig struct {
 }
 
 type DNSSECConfig struct {
-	Enabled          bool   `yaml:"enabled"          envconfig:"DNSSEC_ENABLED"`
-	TrustAnchors     string `yaml:"trustAnchors"     envconfig:"DNSSEC_TRUST_ANCHORS"`
-	TrustAnchorsFile string `yaml:"trustAnchorsFile" envconfig:"DNSSEC_TRUST_ANCHORS_FILE"`
+	Enabled                   bool          `yaml:"enabled"                     envconfig:"DNSSEC_ENABLED"`
+	TrustAnchors              string        `yaml:"trustAnchors"                envconfig:"DNSSEC_TRUST_ANCHORS"`
+	TrustAnchorsFile          string        `yaml:"trustAnchorsFile"            envconfig:"DNSSEC_TRUST_ANCHORS_FILE"`
+	RootAnchorRefreshInterval time.Duration `yaml:"rootAnchorRefreshInterval"   envconfig:"DNSSEC_ROOT_ANCHOR_REFRESH_INTERVAL"`
+	RootAnchorHoldDown        time.Duration `yaml:"rootAnchorHoldDown"          envconfig:"DNSSEC_ROOT_ANCHOR_HOLD_DOWN"`
 }
 
 type DebugConfig struct {
@@ -111,7 +114,9 @@ var globalConfig = &Config{
 		RetryDelayMs:   100,
 		QueryTimeoutMs: 5000,
 		DNSSEC: DNSSECConfig{
-			TrustAnchors: string(defaultTrustAnchors),
+			TrustAnchors:              string(defaultTrustAnchors),
+			RootAnchorRefreshInterval: 24 * time.Hour,
+			RootAnchorHoldDown:        30 * 24 * time.Hour,
 		},
 		SOA: SOAConfig{
 			Mname:   "ns1.cdnsd.localhost.",
@@ -239,6 +244,12 @@ func Load(configFile string) (*Config, error) {
 			)
 		}
 		globalConfig.Dns.DNSSEC.TrustAnchors = string(anchorsContent)
+	}
+	if globalConfig.Dns.DNSSEC.RootAnchorRefreshInterval <= 0 {
+		globalConfig.Dns.DNSSEC.RootAnchorRefreshInterval = 24 * time.Hour
+	}
+	if globalConfig.Dns.DNSSEC.RootAnchorHoldDown <= 0 {
+		globalConfig.Dns.DNSSEC.RootAnchorHoldDown = 30 * 24 * time.Hour
 	}
 	return globalConfig, nil
 }

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -41,9 +41,10 @@ var metricQueryTotal = promauto.NewCounter(prometheus.CounterOpts{
 // Resolver handles DNS queries using configured root hints for
 // recursive resolution.
 type Resolver struct {
-	rootHints     map[uint16]map[string][]dns.RR
-	dnssecEnabled bool
-	trustAnchors  map[string][]dns.RR
+	rootHints         map[uint16]map[string][]dns.RR
+	dnssecEnabled     bool
+	trustAnchors      map[string][]dns.RR
+	rootAnchorManager *rootAnchorManager
 }
 
 // NewResolver creates a resolver from the provided config.
@@ -56,6 +57,9 @@ func NewResolver(cfg *config.Config) (*Resolver, error) {
 	}
 	if err := resolver.loadTrustAnchors(cfg); err != nil {
 		return nil, err
+	}
+	if resolver.dnssecEnabled {
+		resolver.rootAnchorManager = newRootAnchorManager(resolver, cfg)
 	}
 	return resolver, nil
 }
@@ -215,8 +219,9 @@ func (r *Resolver) resolveNameserverAddress(
 
 // Server owns the DNS listeners started by Start.
 type Server struct {
-	servers []*dns.Server
-	errCh   chan error
+	servers         []*dns.Server
+	errCh           chan error
+	stopRootAnchors func()
 
 	stopOnce sync.Once
 	stopErr  error
@@ -237,6 +242,9 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 	s.stopOnce.Do(func() {
 		var errs []error
+		if s.stopRootAnchors != nil {
+			s.stopRootAnchors()
+		}
 		for _, server := range s.servers {
 			if err := server.ShutdownContext(ctx); err != nil && !isServerNotStarted(err) {
 				errs = append(errs, err)
@@ -477,7 +485,13 @@ func Start() (*Server, error) {
 		servers: servers,
 		errCh:   make(chan error, len(servers)),
 	}
+	if resolver.rootAnchorManager != nil {
+		server.stopRootAnchors = resolver.rootAnchorManager.start()
+	}
 	if err := startDNSListeners(server, servers); err != nil {
+		if server.stopRootAnchors != nil {
+			server.stopRootAnchors()
+		}
 		return nil, err
 	}
 	return server, nil

--- a/internal/dns/dnssec.go
+++ b/internal/dns/dnssec.go
@@ -80,7 +80,12 @@ func (r *Resolver) configuredTrustAnchors(zone string) []dns.RR {
 	if r == nil || !r.dnssecEnabled {
 		return nil
 	}
-	return slices.Clone(r.trustAnchors[canonicalDNSName(zone)])
+	zone = canonicalDNSName(zone)
+	anchors := slices.Clone(r.trustAnchors[zone])
+	if zone == "." && r.rootAnchorManager != nil {
+		anchors = append(anchors, r.rootAnchorManager.learnedAnchors()...)
+	}
+	return anchors
 }
 
 // trustAnchorsForZone combines operator-configured anchors with DS

--- a/internal/dns/root_anchor.go
+++ b/internal/dns/root_anchor.go
@@ -1,0 +1,390 @@
+// Copyright 2026 Blink Labs Software
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package dns
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/cdnsd/internal/config"
+	"github.com/blinklabs-io/cdnsd/internal/state"
+	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	rootAnchorPendingAdd    = "add_pending"
+	rootAnchorValid         = "valid"
+	rootAnchorPendingRemove = "remove_pending"
+)
+
+var metricRootAnchorTransitions = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "dnssec_root_anchor_transition_total",
+		Help: "root trust-anchor state transitions",
+	},
+	[]string{"state"},
+)
+
+var metricRootAnchorActive = promauto.NewGauge(
+	prometheus.GaugeOpts{
+		Name: "dnssec_root_anchor_active",
+		Help: "number of active learned root trust anchors",
+	},
+)
+
+type persistedRootAnchor struct {
+	Record    string    `json:"record"`
+	Status    string    `json:"status"`
+	FirstSeen time.Time `json:"first_seen"`
+}
+
+type persistedRootAnchorState struct {
+	Version     int                   `json:"version"`
+	Anchors     []persistedRootAnchor `json:"anchors"`
+	LastRefresh time.Time             `json:"last_refresh"`
+}
+
+type rootAnchorManager struct {
+	resolver    *Resolver
+	config      *config.Config
+	holdDown    time.Duration
+	mu          sync.RWMutex
+	anchors     []persistedRootAnchor
+	lastRefresh time.Time
+
+	// fetch is replaceable in tests. Production refreshes query a root server
+	// selected from the configured root hints.
+	fetch func(context.Context) (*dns.Msg, error)
+}
+
+func newRootAnchorManager(
+	resolver *Resolver,
+	cfg *config.Config,
+) *rootAnchorManager {
+	manager := &rootAnchorManager{
+		resolver: resolver,
+		config:   cfg,
+		holdDown: cfg.Dns.DNSSEC.RootAnchorHoldDown,
+	}
+	manager.fetch = manager.fetchRootDNSKEY
+	manager.load()
+	manager.updateMetrics()
+	return manager
+}
+
+func (m *rootAnchorManager) load() {
+	value, err := state.GetState().GetDNSSECRootAnchorState()
+	if err != nil {
+		if !errors.Is(err, state.ErrStateNotLoaded) {
+			slog.Warn("failed to load persisted DNSSEC root trust-anchor state", "error", err)
+		}
+		return
+	}
+	if len(value) == 0 {
+		return
+	}
+	var persisted persistedRootAnchorState
+	if err := json.Unmarshal(value, &persisted); err != nil || persisted.Version != 1 {
+		slog.Warn("ignoring invalid persisted DNSSEC root trust-anchor state", "error", err)
+		return
+	}
+	for _, anchor := range persisted.Anchors {
+		rr, err := dns.NewRR(anchor.Record)
+		invalidStatus := anchor.Status != rootAnchorPendingAdd &&
+			anchor.Status != rootAnchorValid &&
+			anchor.Status != rootAnchorPendingRemove
+		if err != nil || !supportedTrustAnchor(rr) || invalidStatus {
+			slog.Warn("ignoring invalid persisted DNSSEC root trust anchor", "record", anchor.Record)
+			continue
+		}
+		m.anchors = append(m.anchors, anchor)
+	}
+	m.lastRefresh = persisted.LastRefresh
+}
+
+func (m *rootAnchorManager) fetchRootDNSKEY(ctx context.Context) (*dns.Msg, error) {
+	address := m.resolver.getRandomRootServer()
+	if address == "" {
+		return nil, errors.New("no root server available for trust-anchor refresh")
+	}
+	query := new(dns.Msg)
+	query.SetQuestion(".", dns.TypeDNSKEY)
+	return exchangeDNS(ctx, dnssecQuery(query), address,
+		time.Duration(m.config.Dns.QueryTimeoutMs)*time.Millisecond)
+}
+
+func (m *rootAnchorManager) currentAnchors() []dns.RR {
+	anchors := slices.Clone(m.resolver.trustAnchors["."])
+	return append(anchors, m.learnedAnchors()...)
+}
+
+func (m *rootAnchorManager) learnedAnchors() []dns.RR {
+	var anchors []dns.RR
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, persisted := range m.anchors {
+		if persisted.Status != rootAnchorValid &&
+			persisted.Status != rootAnchorPendingRemove {
+			continue
+		}
+		rr, err := dns.NewRR(persisted.Record)
+		if err == nil && supportedTrustAnchor(rr) {
+			anchors = append(anchors, rr)
+		}
+	}
+	return anchors
+}
+
+func rootAnchorKey(key *dns.DNSKEY) string {
+	if key == nil {
+		return ""
+	}
+	normalized := *key
+	normalized.Flags &^= dns.REVOKE
+	return fmt.Sprintf("%d/%d/%s", normalized.KeyTag(), normalized.Algorithm, normalized.PublicKey)
+}
+
+func rootAnchorRecord(key *dns.DNSKEY) string {
+	copy := *key
+	copy.Hdr.Ttl = 0
+	return copy.String()
+}
+
+func parseRootAnchor(record string) (*dns.DNSKEY, error) {
+	rr, err := dns.NewRR(record)
+	if err != nil {
+		return nil, err
+	}
+	key, ok := rr.(*dns.DNSKEY)
+	if !ok || canonicalDNSName(key.Hdr.Name) != "." {
+		return nil, errors.New("root trust anchor is not a root DNSKEY")
+	}
+	return key, nil
+}
+
+func (m *rootAnchorManager) refresh(ctx context.Context) error {
+	resp, err := m.fetch(ctx)
+	if err != nil {
+		metricRootAnchorTransitions.WithLabelValues("failure").Inc()
+		return fmt.Errorf("fetch root DNSKEY: %w", err)
+	}
+	if resp == nil || resp.Rcode != dns.RcodeSuccess {
+		metricRootAnchorTransitions.WithLabelValues("failure").Inc()
+		return fmt.Errorf("root DNSKEY query returned %s", rcodeString(resp))
+	}
+	keys := dnskeysFrom(resp.Answer, ".")
+	if len(keys) == 0 {
+		metricRootAnchorTransitions.WithLabelValues("failure").Inc()
+		return errors.New("root DNSKEY response contained no DNSKEY records")
+	}
+	if err := authenticateDNSKEYSet(
+		toRRs(keys),
+		signaturesFor(resp.Answer, ".", dns.TypeDNSKEY),
+		keys,
+		m.currentAnchors(),
+	); err != nil {
+		metricRootAnchorTransitions.WithLabelValues("failure").Inc()
+		return fmt.Errorf("authenticate root DNSKEY response: %w", err)
+	}
+
+	now := time.Now().UTC()
+	m.mu.Lock()
+	changed, err := m.apply(keys, now)
+	if err == nil {
+		m.lastRefresh = now
+	}
+	m.mu.Unlock()
+	if err != nil {
+		metricRootAnchorTransitions.WithLabelValues("failure").Inc()
+		return err
+	}
+	if changed || m.lastRefresh.Equal(now) {
+		if err := m.persist(); err != nil {
+			metricRootAnchorTransitions.WithLabelValues("failure").Inc()
+			return fmt.Errorf("persist root trust-anchor state: %w", err)
+		}
+	}
+	m.updateMetrics()
+	slog.Info("authenticated root DNSSEC trust-anchor refresh", "active", m.activeCount())
+	return nil
+}
+
+func toRRs(keys []*dns.DNSKEY) []dns.RR {
+	ret := make([]dns.RR, 0, len(keys))
+	for _, key := range keys {
+		ret = append(ret, key)
+	}
+	return ret
+}
+
+func (m *rootAnchorManager) apply(
+	keys []*dns.DNSKEY,
+	now time.Time,
+) (bool, error) {
+	byID := make(map[string]*dns.DNSKEY, len(keys))
+	revoked := make(map[string]struct{})
+	for _, key := range keys {
+		if key.Flags&dns.SEP == 0 {
+			continue
+		}
+		if key.Flags&dns.REVOKE != 0 {
+			revoked[rootAnchorKey(key)] = struct{}{}
+		} else {
+			byID[rootAnchorKey(key)] = key
+		}
+	}
+	known := make(map[string]struct{}, len(m.anchors))
+	changed := false
+	for idx := 0; idx < len(m.anchors); {
+		anchor := &m.anchors[idx]
+		key, err := parseRootAnchor(anchor.Record)
+		if err != nil {
+			return false, err
+		}
+		id := rootAnchorKey(key)
+		known[id] = struct{}{}
+		if _, isRevoked := revoked[id]; isRevoked {
+			m.anchors = append(m.anchors[:idx], m.anchors[idx+1:]...)
+			changed = true
+			metricRootAnchorTransitions.WithLabelValues("revoked").Inc()
+			slog.Warn("root DNSSEC trust anchor revoked", "key_tag", key.KeyTag())
+			continue
+		}
+		candidate, present := byID[id]
+		if present {
+			if anchor.Status == rootAnchorPendingAdd &&
+				now.Sub(anchor.FirstSeen) >= m.holdDown {
+				anchor.Status = rootAnchorValid
+				changed = true
+				metricRootAnchorTransitions.WithLabelValues(rootAnchorValid).Inc()
+				slog.Info("root DNSSEC trust anchor accepted after hold-down", "key_tag", candidate.KeyTag())
+			} else if anchor.Status == rootAnchorPendingRemove {
+				anchor.Status = rootAnchorValid
+				changed = true
+				metricRootAnchorTransitions.WithLabelValues(rootAnchorValid).Inc()
+			}
+			idx++
+			continue
+		}
+		switch anchor.Status {
+		case rootAnchorPendingAdd:
+			m.anchors = append(m.anchors[:idx], m.anchors[idx+1:]...)
+			changed = true
+			metricRootAnchorTransitions.WithLabelValues("add_failed").Inc()
+			continue
+		case rootAnchorValid:
+			anchor.Status = rootAnchorPendingRemove
+			anchor.FirstSeen = now
+			changed = true
+			metricRootAnchorTransitions.WithLabelValues(rootAnchorPendingRemove).Inc()
+		case rootAnchorPendingRemove:
+			if now.Sub(anchor.FirstSeen) >= m.holdDown {
+				m.anchors = append(m.anchors[:idx], m.anchors[idx+1:]...)
+				changed = true
+				metricRootAnchorTransitions.WithLabelValues("removed").Inc()
+				continue
+			}
+		}
+		idx++
+	}
+	for _, key := range keys {
+		if key.Flags&dns.SEP == 0 || key.Flags&dns.REVOKE != 0 {
+			continue
+		}
+		id := rootAnchorKey(key)
+		if _, ok := known[id]; ok {
+			continue
+		}
+		m.anchors = append(m.anchors, persistedRootAnchor{
+			Record:    rootAnchorRecord(key),
+			Status:    rootAnchorPendingAdd,
+			FirstSeen: now,
+		})
+		changed = true
+		metricRootAnchorTransitions.WithLabelValues(rootAnchorPendingAdd).Inc()
+		slog.Info("new root DNSSEC trust anchor observed; hold-down started", "key_tag", key.KeyTag())
+	}
+	return changed, nil
+}
+
+func (m *rootAnchorManager) persist() error {
+	m.mu.RLock()
+	persisted := persistedRootAnchorState{
+		Version:     1,
+		Anchors:     slices.Clone(m.anchors),
+		LastRefresh: m.lastRefresh,
+	}
+	m.mu.RUnlock()
+	value, err := json.Marshal(persisted)
+	if err != nil {
+		return err
+	}
+	if err := state.GetState().SetDNSSECRootAnchorState(value); err != nil {
+		if errors.Is(err, state.ErrStateNotLoaded) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (m *rootAnchorManager) activeCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	count := 0
+	for _, anchor := range m.anchors {
+		if anchor.Status == rootAnchorValid || anchor.Status == rootAnchorPendingRemove {
+			count++
+		}
+	}
+	return count
+}
+
+func (m *rootAnchorManager) updateMetrics() {
+	metricRootAnchorActive.Set(float64(m.activeCount()))
+}
+
+func (m *rootAnchorManager) start() func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		refresh := func() {
+			refreshCtx, refreshCancel := context.WithTimeout(
+				ctx,
+				time.Duration(m.config.Dns.QueryTimeoutMs)*time.Millisecond,
+			)
+			if err := m.refresh(refreshCtx); err != nil {
+				slog.Warn("DNSSEC root trust-anchor refresh failed", "error", err)
+			}
+			refreshCancel()
+		}
+		refresh()
+		ticker := time.NewTicker(m.config.Dns.DNSSEC.RootAnchorRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				refresh()
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
+}

--- a/internal/dns/root_anchor_test.go
+++ b/internal/dns/root_anchor_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Blink Labs Software
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package dns
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/cdnsd/internal/config"
+	"github.com/miekg/dns"
+)
+
+func TestRootAnchorRFC5011Lifecycle(t *testing.T) {
+	key, _ := newTestDNSSECKey(t, ".")
+	key2, _ := newTestDNSSECKey(t, ".")
+	now := time.Unix(1000, 0).UTC()
+	m := &rootAnchorManager{
+		holdDown: time.Hour,
+		anchors: []persistedRootAnchor{{
+			Record:    rootAnchorRecord(key),
+			Status:    rootAnchorValid,
+			FirstSeen: now,
+		}},
+	}
+
+	changed, err := m.apply([]*dns.DNSKEY{key, key2}, now)
+	if err != nil || !changed || len(m.anchors) != 2 {
+		t.Fatalf("initial rollover apply = %v, %v; anchors=%v", changed, err, m.anchors)
+	}
+	if m.anchors[1].Status != rootAnchorPendingAdd {
+		t.Fatalf("new key status = %q, want %q", m.anchors[1].Status, rootAnchorPendingAdd)
+	}
+
+	_, err = m.apply([]*dns.DNSKEY{key, key2}, now.Add(2*time.Hour))
+	if err != nil || m.anchors[1].Status != rootAnchorValid {
+		t.Fatalf("hold-down apply = %v; anchors=%v", err, m.anchors)
+	}
+
+	_, err = m.apply([]*dns.DNSKEY{key2}, now.Add(3*time.Hour))
+	if err != nil || m.anchors[0].Status != rootAnchorPendingRemove {
+		t.Fatalf("removal start = %v; anchors=%v", err, m.anchors)
+	}
+	_, err = m.apply([]*dns.DNSKEY{key2}, now.Add(5*time.Hour))
+	if err != nil || len(m.anchors) != 1 || rootAnchorKey(mustRootKey(t, m.anchors[0].Record)) != rootAnchorKey(key2) {
+		t.Fatalf("removal completion = %v; anchors=%v", err, m.anchors)
+	}
+
+	key2.Flags |= dns.REVOKE
+	_, err = m.apply([]*dns.DNSKEY{key2}, now.Add(6*time.Hour))
+	if err != nil || len(m.anchors) != 0 {
+		t.Fatalf("revocation apply = %v; anchors=%v", err, m.anchors)
+	}
+}
+
+func TestRootAnchorRefreshRejectsUnauthenticatedResponse(t *testing.T) {
+	key, _ := newTestDNSSECKey(t, ".")
+	other, _ := newTestDNSSECKey(t, ".")
+	cfg := *config.GetConfig()
+	cfg.Dns.DNSSEC.Enabled = true
+	cfg.Dns.DNSSEC.TrustAnchors = testDS(t, key).String()
+	resolver, err := NewResolver(&cfg)
+	if err != nil {
+		t.Fatalf("NewResolver() error = %v", err)
+	}
+	m := resolver.rootAnchorManager
+	m.fetch = func(context.Context) (*dns.Msg, error) {
+		msg := new(dns.Msg)
+		msg.Rcode = dns.RcodeSuccess
+		msg.Answer = []dns.RR{other}
+		return msg, nil
+	}
+	if err := m.refresh(context.Background()); err == nil ||
+		!strings.Contains(err.Error(), "authenticate root DNSKEY") {
+		t.Fatalf("refresh() error = %v, want authentication failure", err)
+	}
+	if len(m.anchors) != 0 {
+		t.Fatalf("failed refresh changed persisted anchors: %v", m.anchors)
+	}
+
+	// The bootstrap DS itself remains usable after a failed update.
+	anchors := resolver.configuredTrustAnchors(".")
+	if len(anchors) == 0 || !dnskeyMatchesAnchor(key, anchors[0]) {
+		t.Fatal("failed update replaced bootstrap anchor")
+	}
+}
+
+func TestRootAnchorStatePersistsAcrossRestart(t *testing.T) {
+	loadIsolatedTestState(t)
+	key, _ := newTestDNSSECKey(t, ".")
+	cfg := *config.GetConfig()
+	cfg.Dns.DNSSEC.Enabled = true
+	cfg.Dns.DNSSEC.RootAnchorHoldDown = time.Hour
+	resolver := &Resolver{trustAnchors: map[string][]dns.RR{".": {testDS(t, key)}}}
+	m := newRootAnchorManager(resolver, &cfg)
+	now := time.Now().UTC()
+	m.anchors = []persistedRootAnchor{{
+		Record:    rootAnchorRecord(key),
+		Status:    rootAnchorPendingAdd,
+		FirstSeen: now,
+	}}
+	m.lastRefresh = now
+	if err := m.persist(); err != nil {
+		t.Fatalf("persist() error = %v", err)
+	}
+	loaded := newRootAnchorManager(resolver, &cfg)
+	if len(loaded.anchors) != 1 || !loaded.anchors[0].FirstSeen.Equal(now) {
+		t.Fatalf("loaded state = %v, want hold-down timestamp preserved", loaded.anchors)
+	}
+}
+
+func mustRootKey(t *testing.T, record string) *dns.DNSKEY {
+	t.Helper()
+	key, err := parseRootAnchor(record)
+	if err != nil {
+		t.Fatalf("parseRootAnchor() error = %v", err)
+	}
+	return key
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -35,6 +35,7 @@ const (
 	handshakeNameHashKeyPrefix = "hs_name_hash_"
 	handshakeDomainKeyPrefix   = "hs_d_"
 	handshakeRecordKeyPrefix   = "hs_r_"
+	dnssecRootAnchorStateKey   = "dnssec_root_anchor_state"
 )
 
 // ErrStateNotLoaded is returned when an operation needs a loaded state database.
@@ -628,6 +629,32 @@ func (s *State) GetHandshakeCursor() (string, error) {
 		return "", nil
 	}
 	return blockHash, err
+}
+
+// GetDNSSECRootAnchorState returns the opaque, persisted RFC 5011 state.
+// Keeping serialization in the DNS package lets state remain independent of
+// the trust-anchor state machine while still providing atomic persistence.
+func (s *State) GetDNSSECRootAnchorState() ([]byte, error) {
+	var value []byte
+	err := s.view(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(dnssecRootAnchorStateKey))
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		value, err = item.ValueCopy(nil)
+		return err
+	})
+	return value, err
+}
+
+// SetDNSSECRootAnchorState atomically replaces the persisted RFC 5011 state.
+func (s *State) SetDNSSECRootAnchorState(value []byte) error {
+	return s.update(func(txn *badger.Txn) error {
+		return txn.Set([]byte(dnssecRootAnchorStateKey), value)
+	})
 }
 
 func (s *State) AddHandshakeName(name string) error {


### PR DESCRIPTION
## Summary
- Implement authenticated RFC 5011 root DNSKEY refresh with add/remove hold-down and revoke handling.
- Persist learned anchor state across restarts and retain the last known-good set on failures.
- Add lifecycle refresh, metrics/logging, configuration, recovery documentation, and rollover tests.

## Tests
- `go test ./...`

Fixes #616

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates the RFC 5011 lifecycle for root DNSSEC trust anchors with authenticated refresh, hold-down, revoke, and persistence. Learned anchors are merged with configured anchors for ".", retained across restarts, and exposed via metrics with simple tuning knobs.

- **New Features**
  - RFC 5011 automation for root DNSKEY: add/remove hold-down and revoke; runs on startup and on an interval.
  - Authenticated refresh via root hints; failed or unsigned updates are rejected and the last known-good set is kept.
  - Persists learned anchors in state and merges them with operator-provided anchors; background refresher shuts down cleanly.
  - Metrics: dnssec_root_anchor_transition_total, dnssec_root_anchor_active.

- **Migration**
  - Defaults: 24h refresh, 30d hold-down.
  - Tune via `dns.dnssec.rootAnchorRefreshInterval` (`DNSSEC_ROOT_ANCHOR_REFRESH_INTERVAL`) and `dns.dnssec.rootAnchorHoldDown` (`DNSSEC_ROOT_ANCHOR_HOLD_DOWN`).
  - Recovery: stop the service, remove `dnssec_root_anchor_state` from the state dir, then restart with a verified `dns.dnssec.trustAnchorsFile`.

<sup>Written for commit 29023a1230bc163e752e6e40006ca50cd12136b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cdnsd/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

