### PR TITLE
fix: avoid repeated local DNSSEC denial scans

### DIFF
--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -987,6 +987,13 @@ func lookupLocalZoneDNSSECRecords(
 	zone string,
 	fromHandshake bool,
 ) ([]dns.RR, error) {
+	return lookupCachedLocalZoneDNSSECRecords(zone, fromHandshake)
+}
+
+func lookupLocalZoneDNSSECRecordsUncached(
+	zone string,
+	fromHandshake bool,
+) ([]dns.RR, error) {
 	recordTypes := []string{"NSEC", "NSEC3", "RRSIG"}
 	var (
 		records []state.DomainRecord

--- a/internal/dns/dnssec_test.go
+++ b/internal/dns/dnssec_test.go
@@ -948,7 +948,7 @@ func TestOnChainDSBecomesTrustAnchor(t *testing.T) {
 	}
 }
 
-func loadIsolatedTestState(t *testing.T) {
+func loadIsolatedTestState(t testing.TB) {
 	t.Helper()
 	cfg := config.GetConfig()
 	oldDirectory := cfg.State.Directory
@@ -971,6 +971,37 @@ func loadIsolatedTestState(t *testing.T) {
 			}
 		}
 	})
+}
+
+func BenchmarkLocalDNSSECProofLookupDoesNotRescanCachedZone(b *testing.B) {
+	for _, unrelatedRecords := range []int{1, 1024} {
+		b.Run(fmt.Sprintf("unrelated-%d", unrelatedRecords), func(b *testing.B) {
+			loadIsolatedTestState(b)
+			zone := fmt.Sprintf("bench-%d.", unrelatedRecords)
+			records := make([]state.DomainRecord, 0, unrelatedRecords)
+			for idx := range unrelatedRecords {
+				records = append(records, state.DomainRecord{
+					Lhs:  fmt.Sprintf("n%d.%s", idx, zone),
+					Type: "NSEC",
+					Rhs:  fmt.Sprintf("z.%s NSEC", zone),
+				})
+			}
+			if err := state.GetState().UpdateDomain(zone, records); err != nil {
+				b.Fatalf("UpdateDomain() error = %v", err)
+			}
+			if _, err := lookupCachedLocalZoneDNSSECRecords(zone, false); err != nil {
+				b.Fatalf("warm cache lookup error = %v", err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if _, err := lookupCachedLocalZoneDNSSECRecords(zone, false); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }
 
 func TestLocalAuthenticatedDenialResponses(t *testing.T) {
@@ -1158,6 +1189,53 @@ func TestLocalDNSSECRecordsDoNotMixRoots(t *testing.T) {
 	if len(records) != 1 ||
 		canonicalDNSName(records[0].Header().Name) != zone {
 		t.Fatalf("local DNSSEC records crossed roots: %v", records)
+	}
+}
+
+func TestLocalDNSSECProofCacheInvalidatesAndIsConcurrent(t *testing.T) {
+	loadIsolatedTestState(t)
+	zone := "cache."
+	record := state.DomainRecord{
+		Lhs:  zone,
+		Type: "NSEC",
+		Rhs:  "z.cache. NSEC",
+	}
+	if err := state.GetState().UpdateDomain(zone, []state.DomainRecord{record}); err != nil {
+		t.Fatalf("UpdateDomain() error = %v", err)
+	}
+	records, err := lookupLocalZoneDNSSECRecords(zone, false)
+	if err != nil || len(records) != 1 {
+		t.Fatalf("initial cached lookup = %v, %v; want one record", records, err)
+	}
+
+	const queryCount = 16
+	errCh := make(chan error, queryCount)
+	for range queryCount {
+		go func() {
+			got, lookupErr := lookupLocalZoneDNSSECRecords(zone, false)
+			if lookupErr != nil {
+				errCh <- lookupErr
+				return
+			}
+			if len(got) != 1 {
+				errCh <- fmt.Errorf("concurrent cached lookup returned %d records", len(got))
+				return
+			}
+			errCh <- nil
+		}()
+	}
+	for range queryCount {
+		if err := <-errCh; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := state.GetState().UpdateDomain(zone, nil); err != nil {
+		t.Fatalf("remove UpdateDomain() error = %v", err)
+	}
+	records, err = lookupLocalZoneDNSSECRecords(zone, false)
+	if err != nil || len(records) != 0 {
+		t.Fatalf("lookup after removal = %v, %v; want empty result", records, err)
 	}
 }
 

--- a/internal/dns/local_dnssec_cache.go
+++ b/internal/dns/local_dnssec_cache.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Blink Labs Software
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package dns
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+
+	"github.com/blinklabs-io/cdnsd/internal/state"
+	"github.com/miekg/dns"
+	"golang.org/x/sync/singleflight"
+)
+
+// localDNSSECProofCacheSize is the number of revisions retained independently
+// for each zone and source namespace.
+const localDNSSECProofCacheSize = 64
+
+const localDNSSECProofCacheZoneLimit = 64
+
+type localDNSSECProofCacheKey struct {
+	instance  uint64
+	revision  uint64
+	zone      string
+	handshake bool
+}
+
+type localDNSSECProofCacheZoneKey struct {
+	zone      string
+	handshake bool
+}
+
+type localDNSSECProofCacheEntry struct {
+	key     localDNSSECProofCacheKey
+	records []dns.RR
+}
+
+type localDNSSECProofCacheZone struct {
+	entries map[localDNSSECProofCacheKey]*list.Element
+	lru     *list.List
+	global  *list.Element
+}
+
+type localDNSSECProofCache struct {
+	mu      sync.Mutex
+	zones   map[localDNSSECProofCacheZoneKey]*localDNSSECProofCacheZone
+	zoneLRU *list.List
+	flight  singleflight.Group
+}
+
+var localProofCache = localDNSSECProofCache{
+	zones:   make(map[localDNSSECProofCacheZoneKey]*localDNSSECProofCacheZone),
+	zoneLRU: list.New(),
+}
+
+func (k localDNSSECProofCacheKey) zoneKey() localDNSSECProofCacheZoneKey {
+	return localDNSSECProofCacheZoneKey{
+		zone:      k.zone,
+		handshake: k.handshake,
+	}
+}
+
+func (k localDNSSECProofCacheKey) flightKey() string {
+	return fmt.Sprintf(
+		"%d\x00%d\x00%s\x00%t",
+		k.instance,
+		k.revision,
+		k.zone,
+		k.handshake,
+	)
+}
+
+func (c *localDNSSECProofCache) cached(
+	key localDNSSECProofCacheKey,
+) ([]dns.RR, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	zone := c.zones[key.zoneKey()]
+	if zone == nil {
+		return nil, false
+	}
+	if zone.global != nil {
+		c.zoneLRU.MoveToFront(zone.global)
+	}
+	element := zone.entries[key]
+	if element == nil {
+		return nil, false
+	}
+	zone.lru.MoveToFront(element)
+	return element.Value.(localDNSSECProofCacheEntry).records, true
+}
+
+func (c *localDNSSECProofCache) store(
+	key localDNSSECProofCacheKey,
+	records []dns.RR,
+) []dns.RR {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	zoneKey := key.zoneKey()
+	zone := c.zones[zoneKey]
+	if zone == nil {
+		if c.zoneLRU.Len() >= localDNSSECProofCacheZoneLimit {
+			oldest := c.zoneLRU.Back()
+			if oldest != nil {
+				delete(c.zones, oldest.Value.(localDNSSECProofCacheZoneKey))
+				c.zoneLRU.Remove(oldest)
+			}
+		}
+		zone = &localDNSSECProofCacheZone{
+			entries: make(map[localDNSSECProofCacheKey]*list.Element),
+			lru:     list.New(),
+		}
+		zone.global = c.zoneLRU.PushFront(zoneKey)
+		c.zones[zoneKey] = zone
+	} else if zone.global != nil {
+		c.zoneLRU.MoveToFront(zone.global)
+	}
+	if existing := zone.entries[key]; existing != nil {
+		zone.lru.MoveToFront(existing)
+		return existing.Value.(localDNSSECProofCacheEntry).records
+	}
+	element := zone.lru.PushFront(localDNSSECProofCacheEntry{
+		key:     key,
+		records: records,
+	})
+	zone.entries[key] = element
+	if zone.lru.Len() > localDNSSECProofCacheSize {
+		oldest := zone.lru.Back()
+		if oldest != nil {
+			delete(zone.entries, oldest.Value.(localDNSSECProofCacheEntry).key)
+			zone.lru.Remove(oldest)
+		}
+	}
+	return records
+}
+
+func lookupCachedLocalZoneDNSSECRecords(
+	zone string,
+	fromHandshake bool,
+) ([]dns.RR, error) {
+	instance, revision, err := state.GetState().DNSSECRevision(fromHandshake)
+	if err != nil {
+		return nil, err
+	}
+	key := localDNSSECProofCacheKey{
+		instance:  instance,
+		revision:  revision,
+		zone:      canonicalDNSName(zone),
+		handshake: fromHandshake,
+	}
+	if records, ok := localProofCache.cached(key); ok {
+		return records, nil
+	}
+	result, err, _ := localProofCache.flight.Do(
+		key.flightKey(),
+		func() (any, error) {
+			if records, ok := localProofCache.cached(key); ok {
+				return records, nil
+			}
+			records, err := lookupLocalZoneDNSSECRecordsUncached(
+				zone,
+				fromHandshake,
+			)
+			if err != nil {
+				return nil, err
+			}
+			return localProofCache.store(key, records), nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return result.([]dns.RR), nil
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/blinklabs-io/cdnsd/internal/config"
@@ -36,6 +37,8 @@ const (
 	handshakeDomainKeyPrefix   = "hs_d_"
 	handshakeRecordKeyPrefix   = "hs_r_"
 	dnssecRootAnchorStateKey   = "dnssec_root_anchor_state"
+	cardanoDNSSECRevisionKey   = "dnssec_revision_cardano"
+	handshakeDNSSECRevisionKey = "dnssec_revision_handshake"
 )
 
 // ErrStateNotLoaded is returned when an operation needs a loaded state database.
@@ -45,11 +48,14 @@ var ErrStateNotLoaded = errors.New("state database is not loaded")
 var ErrStateAlreadyLoaded = errors.New("state database is already loaded")
 
 type State struct {
-	mu      sync.RWMutex
-	db      *badger.DB
-	gcTimer *time.Ticker
-	gcStop  chan struct{}
-	gcDone  chan struct{}
+	mu sync.RWMutex
+	db *badger.DB
+	// instanceID distinguishes a database reload that starts with the same
+	// persisted revision, which is important to users of the state cache.
+	instanceID uint64
+	gcTimer    *time.Ticker
+	gcStop     chan struct{}
+	gcDone     chan struct{}
 }
 
 type DomainRecord struct {
@@ -66,6 +72,8 @@ type DiscoveredAddress struct {
 }
 
 var globalState = &State{}
+
+var stateInstanceCounter atomic.Uint64
 
 func (s *State) Load() error {
 	s.mu.Lock()
@@ -93,6 +101,7 @@ func (s *State) Load() error {
 	gcStop := make(chan struct{})
 	gcDone := make(chan struct{})
 	s.db = db
+	s.instanceID = stateInstanceCounter.Add(1)
 	s.gcTimer = gcTimer
 	s.gcStop = gcStop
 	s.gcDone = gcDone
@@ -402,6 +411,7 @@ func (s *State) UpdateDomain(
 		records,
 		cardanoDomainKeyPrefix,
 		cardanoRecordKeyPrefix,
+		false,
 	)
 }
 
@@ -410,6 +420,7 @@ func (s *State) updateDomain(
 	records []DomainRecord,
 	domainKeyPrefix string,
 	recordKeyPrefix string,
+	fromHandshake bool,
 ) error {
 	err := s.update(func(txn *badger.Txn) error {
 		// Add new records
@@ -476,9 +487,76 @@ func (s *State) updateDomain(
 		if err := txn.Set(domainRecordsKey, []byte(recordKeysJoin)); err != nil {
 			return err
 		}
+		revisionKey := cardanoDNSSECRevisionKey
+		if fromHandshake {
+			revisionKey = handshakeDNSSECRevisionKey
+		}
+		if err := bumpRevision(txn, revisionKey); err != nil {
+			return err
+		}
 		return nil
 	})
 	return err
+}
+
+func bumpRevision(txn *badger.Txn, key string) error {
+	var revision uint64
+	item, err := txn.Get([]byte(key))
+	if err != nil && !errors.Is(err, badger.ErrKeyNotFound) {
+		return err
+	}
+	if err == nil {
+		value, valueErr := item.ValueCopy(nil)
+		if valueErr != nil {
+			return valueErr
+		}
+		revision, err = strconv.ParseUint(string(value), 10, 64)
+		if err != nil {
+			return fmt.Errorf("parse DNSSEC state revision: %w", err)
+		}
+	}
+	if revision == ^uint64(0) {
+		return errors.New("DNSSEC state revision exhausted")
+	}
+	return txn.Set([]byte(key), []byte(strconv.FormatUint(revision+1, 10)))
+}
+
+// DNSSECRevision returns a process-local state identity and the persisted
+// revision for one record namespace. The identity changes on every Load so a
+// cache cannot reuse records from a closed and recreated database.
+func (s *State) DNSSECRevision(fromHandshake bool) (uint64, uint64, error) {
+	if s == nil {
+		return 0, 0, ErrStateNotLoaded
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return 0, 0, ErrStateNotLoaded
+	}
+	key := cardanoDNSSECRevisionKey
+	if fromHandshake {
+		key = handshakeDNSSECRevisionKey
+	}
+	var revision uint64
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(key))
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		value, err := item.ValueCopy(nil)
+		if err != nil {
+			return err
+		}
+		revision, err = strconv.ParseUint(string(value), 10, 64)
+		if err != nil {
+			return fmt.Errorf("parse DNSSEC state revision: %w", err)
+		}
+		return nil
+	})
+	return s.instanceID, revision, err
 }
 
 func (s *State) LookupRecords(
@@ -702,6 +780,7 @@ func (s *State) UpdateHandshakeDomain(
 		records,
 		handshakeDomainKeyPrefix,
 		handshakeRecordKeyPrefix,
+		true,
 	)
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -120,6 +120,59 @@ func TestLoadReturnsAlreadyLoadedForLoadedState(t *testing.T) {
 	}
 }
 
+func TestDNSSECRevisionChangesForBothNamespaces(t *testing.T) {
+	s := newLoadedTestState(t)
+	_, revision, err := s.DNSSECRevision(false)
+	if err != nil || revision != 0 {
+		t.Fatalf("initial Cardano revision = %d, %v; want zero", revision, err)
+	}
+	if err := s.UpdateDomain("example", nil); err != nil {
+		t.Fatalf("UpdateDomain() error = %v", err)
+	}
+	_, revision, err = s.DNSSECRevision(false)
+	if err != nil || revision != 1 {
+		t.Fatalf("Cardano revision after update = %d, %v; want one", revision, err)
+	}
+	_, handshakeRevision, err := s.DNSSECRevision(true)
+	if err != nil || handshakeRevision != 0 {
+		t.Fatalf("initial Handshake revision = %d, %v; want zero", handshakeRevision, err)
+	}
+	if err := s.UpdateHandshakeDomain("example", nil); err != nil {
+		t.Fatalf("UpdateHandshakeDomain() error = %v", err)
+	}
+	_, handshakeRevision, err = s.DNSSECRevision(true)
+	if err != nil || handshakeRevision != 1 {
+		t.Fatalf("Handshake revision after update = %d, %v; want one", handshakeRevision, err)
+	}
+}
+
+func TestDNSSECRevisionInstanceChangesAcrossReload(t *testing.T) {
+	s := newLoadedTestState(t)
+	if err := s.UpdateDomain("example", nil); err != nil {
+		t.Fatalf("UpdateDomain() error = %v", err)
+	}
+	instanceBefore, revisionBefore, err := s.DNSSECRevision(false)
+	if err != nil {
+		t.Fatalf("DNSSECRevision() before reload error = %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load() after close error = %v", err)
+	}
+	instanceAfter, revisionAfter, err := s.DNSSECRevision(false)
+	if err != nil {
+		t.Fatalf("DNSSECRevision() after reload error = %v", err)
+	}
+	if instanceBefore == instanceAfter {
+		t.Fatalf("state instance ID did not change across reload: %d", instanceBefore)
+	}
+	if revisionBefore != revisionAfter {
+		t.Fatalf("revision changed across reload: before=%d after=%d", revisionBefore, revisionAfter)
+	}
+}
+
 func TestGetCursorReturnsErrorForMalformedPersistedValues(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary
- Add a bounded per-zone cache for local NSEC/NSEC3/RRSIG denial proofs.
- Persist Cardano and Handshake state revisions so updates and removals invalidate cached proofs safely.
- Add update, concurrency, and revision tests.

## Tests
- `go test ./...`

Fixes #615

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop repeated local DNSSEC denial scans by caching per-zone NSEC/NSEC3/RRSIG proofs with safe invalidation. Faster lookups; cache dedupes concurrent misses and refreshes on Cardano/Handshake state changes and process restarts.

- **Bug Fixes**
  - Add per-zone LRU cache (64 entries) with a global 64-zone LRU in `internal/dns`; cached lookup (`lookupLocalZoneDNSSECRecords`) is now default with an uncached fallback.
  - Use process instance ID + per-namespace DNSSEC revision in `internal/state` for cache keys; bump on updates/removals. Expose `DNSSECRevision()`; keys include canonicalized zone and root (Cardano vs Handshake).
  - Deduplicate concurrent cache misses using `singleflight`; add tests for invalidation, concurrency, cross-root isolation, reload behavior, and a benchmark.

<sup>Written for commit 44c5a6e5aa8b7dbee4886b44fd3fea93c66b7bed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cdnsd/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved local DNSSEC record lookups with a bounded cache for faster repeated requests.
  * Added support for concurrent lookups while maintaining consistent results.

* **Reliability**
  * Cache entries are invalidated when domain state changes, ensuring updated DNSSEC records are returned.
  * DNSSEC revisions are tracked separately for supported record namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->