### PR TITLE
chore: harden runtime and deployment defaults

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -3,7 +3,7 @@ name: Docker CI
 on:
   pull_request:
     branches: ['main']
-    paths: ['Dockerfile','cmd/**','docs/**','internal/**','go.*','.github/workflows/ci-docker.yml']
+    paths: ['Dockerfile','README.md','cmd/**','docs/**','internal/**','go.*','.github/workflows/ci-docker.yml']
 
 env:
   GHCR_IMAGE_NAME: ghcr.io/blinklabs-io/cdnsd

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.25.12, 1.26.5]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -26,3 +26,16 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: go-test
         run: go test ./...
+      - name: go-test-race
+        run: go test -race ./...
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
+        with:
+          go-version: 1.26.5
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.25.12
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.3.0

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.25.12
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: '0'
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.25.12
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
       - name: Upload release asset

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,13 @@ WORKDIR /code
 COPY go.* .
 RUN go mod download
 COPY . .
-RUN make build
+RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o /code/cdnsd ./cmd/cdnsd
+RUN mkdir -p /code/state
 
 FROM cgr.dev/chainguard/glibc-dynamic AS cdnsd
-COPY --from=build /code/cdnsd /bin/
+COPY --from=build --chown=nonroot:nonroot /code/cdnsd /usr/bin/cdnsd
+COPY --from=build --chown=nonroot:nonroot /code/state /var/lib/cdnsd
+WORKDIR /var/lib/cdnsd
+ENV STATE_DIR=/var/lib/cdnsd
+USER nonroot:nonroot
 ENTRYPOINT ["cdnsd"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,37 @@ Resolver for Cardano-based second-level domains on Handshake top-level domains
 
 `cdnsd` supports configuration via YAML config files, and all settings may be overridden with environment variables.
 
+### Production deployment
+
+This repository currently ships only pre-production Cardano profiles. The
+built-in defaults (`ada-preprod` and `auto-preprod`) are for testing and must
+not be used as a production configuration. There are no mainnet profiles in
+this release; configure and independently verify the network, policy, script
+address, and sync intercept before serving any real traffic.
+
+Before exposing the resolver, operators should:
+
+- Set `indexer.verify: true` (the default) and keep it enabled. Disabling it
+  is suitable only for controlled development experiments.
+- Bind DNS to the intended interface explicitly. Set
+  `dns.recursionEnabled: false` unless this instance is protected by network
+  ACLs and is deliberately operated as a recursive resolver.
+- Keep metrics and debug/pprof on loopback or a protected management network.
+  An empty metrics address is treated as loopback by the daemon; an explicit
+  wildcard address exposes it broadly.
+- Put `state.dir` on persistent, private storage and include it in backups.
+  The state contains the indexed data and DNSSEC root-anchor rollover state;
+  do not share it between active instances.
+- Monitor logs, `/healthz`, `/readyz`, and Prometheus metrics. Readiness means
+  the indexer and DNS listeners have started; it does not attest that the
+  configured chain or upstream DNS sources are healthy.
+
+The resolver has not yet implemented every operational property required for
+an internet-facing authoritative or recursive service, including complete
+chain reorganization handling and name expiration handling. Review the
+current issue tracker and test the selected deployment topology before using
+it for production traffic.
+
 ### Top-level Config Options (YAML)
 
 | Option                  | Type         | Environment Variable              | Description |
@@ -70,13 +101,13 @@ logging:
   debug: true
   queryLog: true
 metrics:
-  address: ""
+  address: "127.0.0.1"
   port: 9000
 dns:
   address: "0.0.0.0"
   port: 8053
   tlsPort: 8853
-  recursionEnabled: true
+  recursionEnabled: false
   rootHintsFile: "/etc/cdnsd/named.root"
   dnssec:
     enabled: true
@@ -92,7 +123,7 @@ indexer:
   socketPath: ""
   interceptHash: ""
   interceptSlot: 0
-  verify: false
+  verify: true
   handshakeAddress: ""
 state:
   dir: "/var/lib/cdnsd"
@@ -159,7 +190,27 @@ export DNS_LISTEN_PORT=5353
 cdnsd
 ```
 
+For the container image, mount a persistent volume at `/var/lib/cdnsd`.
+The image sets `STATE_DIR` to that path and runs as the unprivileged
+`nonroot` user. A typical deployment should also publish only the DNS ports
+needed by clients and keep the management listener private:
+
+```sh
+docker run --rm \
+  -v cdnsd-state:/var/lib/cdnsd \
+  -p 8053:8053/udp -p 8053:8053/tcp \
+  ghcr.io/blinklabs-io/cdnsd:TAG
+```
+
 ## Metrics & Observability
 
-- Prometheus: Exposed at `/metrics` (port per config)
-- Debug HTTP/pprof: If debug port is set, accessible for diagnostics
+- Prometheus: Exposed at `/metrics` (port per config; empty address defaults
+  to `127.0.0.1`)
+- Health: `/healthz` reports that the HTTP process is responding;
+  `/readyz` returns `503` until the indexer and DNS listeners have started
+- Debug HTTP/pprof: If the debug port is set, accessible for diagnostics;
+  protect this endpoint because pprof can expose sensitive runtime details
+
+These HTTP endpoints are unauthenticated. Use loopback, firewall rules, or a
+separate authenticated reverse proxy for all management traffic. Do not bind
+metrics or debug to `0.0.0.0` on an untrusted network.

--- a/cmd/cdnsd/main.go
+++ b/cmd/cdnsd/main.go
@@ -17,6 +17,9 @@ import (
 	_ "net/http/pprof" // #nosec G108
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -35,6 +38,72 @@ var cmdlineFlags struct {
 }
 
 const shutdownTimeout = 15 * time.Second
+
+const (
+	httpReadHeaderTimeout = 5 * time.Second
+	httpReadTimeout       = 10 * time.Second
+	httpWriteTimeout      = 10 * time.Second
+	httpIdleTimeout       = 60 * time.Second
+	maxHTTPHeaderBytes    = 1 << 20
+)
+
+type runtimeStatus struct {
+	ready atomic.Bool
+}
+
+func (s *runtimeStatus) healthHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok\n"))
+}
+
+func (s *runtimeStatus) readinessHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	if !s.ready.Load() {
+		http.Error(w, "not ready\n", http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ready\n"))
+}
+
+func (s *runtimeStatus) setReady(ready bool) {
+	s.ready.Store(ready)
+}
+
+func observabilityListenAddress(address string) string {
+	if strings.TrimSpace(address) == "" {
+		return "127.0.0.1"
+	}
+	return address
+}
+
+func httpListenAddress(address string, port uint) string {
+	return net.JoinHostPort(
+		observabilityListenAddress(address),
+		strconv.FormatUint(uint64(port), 10),
+	)
+}
+
+func newHTTPServer(address string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              address,
+		Handler:           handler,
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+		ReadTimeout:       httpReadTimeout,
+		WriteTimeout:      httpWriteTimeout,
+		IdleTimeout:       httpIdleTimeout,
+		MaxHeaderBytes:    maxHTTPHeaderBytes,
+	}
+}
+
+func newMetricsMux(status *runtimeStatus) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/healthz", status.healthHandler)
+	mux.HandleFunc("/readyz", status.readinessHandler)
+	return mux
+}
 
 func slogPrintf(format string, v ...any) {
 	slog.Info(fmt.Sprintf(format, v...))
@@ -103,10 +172,12 @@ func run() int {
 
 	asyncErrCh := make(chan error, 8)
 	indexerSvc := indexer.GetIndexer()
+	status := &runtimeStatus{}
 	var dnsSrv *dns.Server
 	var debugSrv *http.Server
 	var metricsSrv *http.Server
 	shutdown := func() error {
+		status.setReady(false)
 		shutdownCtx, cancel := context.WithTimeout(
 			context.Background(),
 			shutdownTimeout,
@@ -136,22 +207,12 @@ func run() int {
 
 	// Start debug listener
 	if cfg.Debug.ListenPort > 0 {
-		debugListenAddr := fmt.Sprintf(
-			"%s:%d",
+		debugListenAddr := httpListenAddress(
 			cfg.Debug.ListenAddress,
 			cfg.Debug.ListenPort,
 		)
-		slog.Info(
-			fmt.Sprintf(
-				"starting debug listener on %s:%d",
-				cfg.Debug.ListenAddress,
-				cfg.Debug.ListenPort,
-			),
-		)
-		debugSrv = &http.Server{
-			Addr:              debugListenAddr,
-			ReadHeaderTimeout: 60 * time.Second,
-		}
+		slog.Info("starting debug listener on " + debugListenAddr)
+		debugSrv = newHTTPServer(debugListenAddr, http.DefaultServeMux)
 		if err := startHTTPServer("debug", debugSrv, asyncErrCh); err != nil {
 			slog.Error(err.Error())
 			_ = shutdown()
@@ -164,22 +225,14 @@ func run() int {
 
 	// Start metrics listener
 	if cfg.Metrics.ListenPort > 0 {
-		metricsListenAddr := fmt.Sprintf(
-			"%s:%d",
+		metricsListenAddr := httpListenAddress(
 			cfg.Metrics.ListenAddress,
 			cfg.Metrics.ListenPort,
 		)
 		slog.Info(
 			"starting listener for prometheus metrics connections on " + metricsListenAddr,
 		)
-		metricsMux := http.NewServeMux()
-		metricsMux.Handle("/metrics", promhttp.Handler())
-		metricsSrv = &http.Server{
-			Addr:         metricsListenAddr,
-			WriteTimeout: 10 * time.Second,
-			ReadTimeout:  10 * time.Second,
-			Handler:      metricsMux,
-		}
+		metricsSrv = newHTTPServer(metricsListenAddr, newMetricsMux(status))
 		if err := startHTTPServer("metrics", metricsSrv, asyncErrCh); err != nil {
 			slog.Error(err.Error())
 			_ = shutdown()
@@ -214,6 +267,7 @@ func run() int {
 	if signalReceived() {
 		return shutdownAfterSignal()
 	}
+	status.setReady(true)
 
 	var runtimeErr error
 	select {

--- a/cmd/cdnsd/main_test.go
+++ b/cmd/cdnsd/main_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Blink Labs Software
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestObservabilityListenAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		address  string
+		expected string
+	}{
+		{name: "empty", address: "", expected: "127.0.0.1"},
+		{name: "whitespace", address: "  ", expected: "127.0.0.1"},
+		{name: "explicit", address: "0.0.0.0", expected: "0.0.0.0"},
+		{name: "ipv6", address: "::1", expected: "::1"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if actual := observabilityListenAddress(test.address); actual != test.expected {
+				t.Fatalf("observabilityListenAddress(%q) = %q, want %q", test.address, actual, test.expected)
+			}
+		})
+	}
+
+	if actual := httpListenAddress("::1", 8081); actual != "[::1]:8081" {
+		t.Fatalf("httpListenAddress() = %q, want %q", actual, "[::1]:8081")
+	}
+}
+
+func TestNewHTTPServerTimeouts(t *testing.T) {
+	t.Parallel()
+
+	server := newHTTPServer("127.0.0.1:8081", http.NewServeMux())
+	if server.ReadHeaderTimeout != httpReadHeaderTimeout {
+		t.Fatalf("ReadHeaderTimeout = %s, want %s", server.ReadHeaderTimeout, httpReadHeaderTimeout)
+	}
+	if server.ReadTimeout != httpReadTimeout {
+		t.Fatalf("ReadTimeout = %s, want %s", server.ReadTimeout, httpReadTimeout)
+	}
+	if server.WriteTimeout != httpWriteTimeout {
+		t.Fatalf("WriteTimeout = %s, want %s", server.WriteTimeout, httpWriteTimeout)
+	}
+	if server.IdleTimeout != httpIdleTimeout {
+		t.Fatalf("IdleTimeout = %s, want %s", server.IdleTimeout, httpIdleTimeout)
+	}
+	if server.MaxHeaderBytes != maxHTTPHeaderBytes {
+		t.Fatalf("MaxHeaderBytes = %d, want %d", server.MaxHeaderBytes, maxHTTPHeaderBytes)
+	}
+}
+
+func TestRuntimeStatusHandlers(t *testing.T) {
+	t.Parallel()
+
+	status := &runtimeStatus{}
+	mux := newMetricsMux(status)
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	mux.ServeHTTP(response, request)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("initial readiness status = %d, want %d", response.Code, http.StatusServiceUnavailable)
+	}
+
+	status.setReady(true)
+	response = httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("ready status = %d, want %d", response.Code, http.StatusOK)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "ready\n" {
+		t.Fatalf("ready body = %q, want %q", body, "ready\n")
+	}
+
+	response = httptest.NewRecorder()
+	mux.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("health status = %d, want %d", response.Code, http.StatusOK)
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blinklabs-io/cdnsd
 
-go 1.25.7
+go 1.25.12
 
 require (
 	github.com/blinklabs-io/adder v0.42.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens runtime and deployment defaults to reduce exposure and improve health signaling. Adds health/readiness endpoints, safer HTTP defaults, and a non-root container with a persistent state path.

- **New Features**
  - Added `/healthz` and `/readyz`; readiness flips true only after the indexer and DNS listeners start.
  - Empty metrics/debug address now binds to `127.0.0.1`; set an explicit address to expose externally.
  - Hardened HTTP servers with strict timeouts and header limits; added tests for readiness and HTTP settings.
  - Container runs as `nonroot`, installs binary to `/usr/bin/cdnsd`, sets `STATE_DIR=/var/lib/cdnsd`, and expects persistent storage there.
  - Updated README with production deployment guidance and container usage.
  - CI adds `go test -race`, `govulncheck`, and pins Go to `1.25.12`/`1.26.5`.

- **Migration**
  - If you relied on an empty metrics/debug address to expose endpoints, set `metrics.address` (and debug address) explicitly (e.g., `0.0.0.0`).
  - Mount writable storage at `/var/lib/cdnsd` and ensure permissions for the `nonroot` user.
  - Defaults are safer: `dns.recursionEnabled: false`, `indexer.verify: true`, `metrics.address: "127.0.0.1"`. Update your config if you need different behavior.

<sup>Written for commit efdd4898cd9cf1d1253ba40d05156602de1295b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cdnsd/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

