### PR TITLE
fix: harden Handshake chain validation

### DIFF
--- a/handshake/covenant.go
+++ b/handshake/covenant.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"runtime/debug"
 )
 
 // Covenant types
@@ -63,143 +62,42 @@ func (c *GenericCovenant) Decode(r io.Reader) error {
 	return nil
 }
 
-func (c *GenericCovenant) Covenant() Covenant {
+func (c *GenericCovenant) Covenant() (Covenant, error) {
 	switch c.Type {
 	case CovenantTypeNone:
-		ret, err := NewNoneCovenantFromGeneric(c)
-		if err != nil {
-			panic(
-				fmt.Sprintf("can't convert generic covenant to None: %s", err),
-			)
-		}
-		return ret
+		return NewNoneCovenantFromGeneric(c)
 	case CovenantTypeClaim:
-		ret, err := NewClaimCovenantFromGeneric(c)
-		if err != nil {
-			panic(
-				fmt.Sprintf("can't convert generic covenant to Claim: %s", err),
-			)
-		}
-		return ret
+		return NewClaimCovenantFromGeneric(c)
 	case CovenantTypeOpen:
-		ret, err := NewOpenCovenantFromGeneric(c)
-		if err != nil {
-			panic(
-				fmt.Sprintf("can't convert generic covenant to Open: %s", err),
-			)
-		}
-		return ret
+		return NewOpenCovenantFromGeneric(c)
 	case CovenantTypeBid:
-		ret, err := NewBidCovenantFromGeneric(c)
-		if err != nil {
-			panic(fmt.Sprintf("can't convert generic covenant to Bid: %s", err))
-		}
-		return ret
+		return NewBidCovenantFromGeneric(c)
 	case CovenantTypeReveal:
-		ret, err := NewRevealCovenantFromGeneric(c)
-		if err != nil {
-			panic(
-				fmt.Sprintf(
-					"can't convert generic covenant to Reveal: %s",
-					err,
-				),
-			)
-		}
-		return ret
+		return NewRevealCovenantFromGeneric(c)
 	case CovenantTypeRedeem:
-		ret, err := NewRedeemCovenantFromGeneric(c)
-		if err != nil {
-			panic(
-				fmt.Sprintf(
-					"can't convert generic covenant to Redeem: %s",
-					err,
-				),
-			)
-		}
-		return ret
+		return NewRedeemCovenantFromGeneric(c)
 	case CovenantTypeRegister:
-		ret, err := NewRegisterCovenantFromGeneric(c)
-		if err != nil {
-			panic(
-				fmt.Sprintf(
-					"can't convert generic covenant to Register: %s",
-					err,
-				),
-			)
-		}
-		return ret
+		return NewRegisterCovenantFromGeneric(c)
 	case CovenantTypeUpdate:
-		ret, err := NewUpdateCovenantFromGeneric(c)
-		if err != nil {
-			panic(
-				fmt.Sprintf(
-					"can't convert generic covenant to Update: %s",
-					err,
-				),
-			)
-		}
-		return ret
+		return NewUpdateCovenantFromGeneric(c)
 	case CovenantTypeRenew:
-		ret, err := NewRenewCovenantFromGeneric(c)
-		if err != nil {
-			panic(
-				fmt.Sprintf("can't convert generic covenant to Renew: %s", err),
-			)
-		}
-		return ret
+		return NewRenewCovenantFromGeneric(c)
 	case CovenantTypeTransfer:
-		ret, err := NewTransferCovenantFromGeneric(c)
-		if err != nil {
-			panic(
-				fmt.Sprintf(
-					"can't convert generic covenant to Transfer: %s",
-					err,
-				),
-			)
-		}
-		return ret
+		return NewTransferCovenantFromGeneric(c)
 	case CovenantTypeFinalize:
-		ret, err := NewFinalizeCovenantFromGeneric(c)
-		if err != nil {
-			panic(
-				fmt.Sprintf(
-					"can't convert generic covenant to Finalize: %s",
-					err,
-				),
-			)
-		}
-		return ret
+		return NewFinalizeCovenantFromGeneric(c)
 	case CovenantTypeRevoke:
-		ret, err := NewRevokeCovenantFromGeneric(c)
-		if err != nil {
-			panic(
-				fmt.Sprintf(
-					"can't convert generic covenant to Revoke: %s",
-					err,
-				),
-			)
-		}
-		return ret
+		return NewRevokeCovenantFromGeneric(c)
 	default:
-		panic(fmt.Sprintf("unknown covenant type: %d", c.Type))
+		return nil, fmt.Errorf("unknown covenant type: %d", c.Type)
 	}
 }
 
-// CheckedCovenant converts a decoded covenant without panicking. Network
-// input must use this method so malformed covenant items fail closed instead
-// of taking down the process through Covenant's historical panic behavior.
-func (c *GenericCovenant) CheckedCovenant() (ret Covenant, err error) {
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			ret = nil
-			err = fmt.Errorf(
-				"malformed covenant: %v\n%s",
-				recovered,
-				debug.Stack(),
-			)
-		}
-	}()
-	return c.Covenant(), nil
+// CheckedCovenant converts a decoded covenant and returns malformed input as
+// an error. Network input must use this method so malformed covenant items
+// fail closed.
+func (c *GenericCovenant) CheckedCovenant() (Covenant, error) {
+	return c.Covenant()
 }
 
 type NoneCovenant struct{}

--- a/handshake/covenant.go
+++ b/handshake/covenant.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime/debug"
 )
 
 // Covenant types
@@ -191,7 +192,11 @@ func (c *GenericCovenant) CheckedCovenant() (ret Covenant, err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			ret = nil
-			err = fmt.Errorf("malformed covenant: %v", recovered)
+			err = fmt.Errorf(
+				"malformed covenant: %v\n%s",
+				recovered,
+				debug.Stack(),
+			)
 		}
 	}()
 	return c.Covenant(), nil

--- a/handshake/covenant.go
+++ b/handshake/covenant.go
@@ -184,6 +184,19 @@ func (c *GenericCovenant) Covenant() Covenant {
 	}
 }
 
+// CheckedCovenant converts a decoded covenant without panicking. Network
+// input must use this method so malformed covenant items fail closed instead
+// of taking down the process through Covenant's historical panic behavior.
+func (c *GenericCovenant) CheckedCovenant() (ret Covenant, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			ret = nil
+			err = fmt.Errorf("malformed covenant: %v", recovered)
+		}
+	}()
+	return c.Covenant(), nil
+}
+
 type NoneCovenant struct{}
 
 func (NoneCovenant) isCovenant() {}

--- a/handshake/covenant_safety_test.go
+++ b/handshake/covenant_safety_test.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Blink Labs Software
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package handshake_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/cdnsd/handshake"
+)
+
+func TestCheckedCovenantRejectsMalformedInput(t *testing.T) {
+	testCases := []*handshake.GenericCovenant{
+		{Type: handshake.CovenantTypeOpen},
+		{Type: 255},
+	}
+	for _, covenant := range testCases {
+		if _, err := covenant.CheckedCovenant(); err == nil {
+			t.Fatalf("CheckedCovenant accepted malformed covenant %#v", covenant)
+		}
+	}
+}

--- a/handshake/messages.go
+++ b/handshake/messages.go
@@ -174,6 +174,10 @@ func (m *MsgVersion) Encode() []byte {
 }
 
 func (m *MsgVersion) Decode(data []byte) error {
+	const fixedLength = 4 + 8 + 8 + netAddressLength + 8 + 1 + 4 + 1
+	if len(data) < fixedLength {
+		return errors.New("version payload is too short")
+	}
 	m.Version = binary.LittleEndian.Uint32(data[0:4])
 	m.Services = binary.LittleEndian.Uint64(data[4:12])
 	m.Time = binary.LittleEndian.Uint64(data[12:20])
@@ -182,6 +186,9 @@ func (m *MsgVersion) Decode(data []byte) error {
 	}
 	m.Nonce = [8]byte(data[108:116])
 	userAgentLength := int(data[116])
+	if len(data) < fixedLength+userAgentLength {
+		return errors.New("invalid version payload length")
+	}
 	m.Agent = string(data[117 : 117+userAgentLength])
 	m.Height = binary.LittleEndian.Uint32(
 		data[117+userAgentLength : 117+userAgentLength+4],
@@ -425,6 +432,9 @@ func (m *MsgHeaders) Decode(data []byte) error {
 	count, bytesRead, err := ReadUvarint(data)
 	if err != nil {
 		return err
+	}
+	if count > maxBlockHeaders {
+		return fmt.Errorf("too many block headers: %d", count)
 	}
 	data = data[bytesRead:]
 	if len(data) != int(count*BlockHeaderSize) { // nolint:gosec

--- a/handshake/messages_safety_test.go
+++ b/handshake/messages_safety_test.go
@@ -1,0 +1,32 @@
+// Copyright 2025 Blink Labs Software
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package handshake
+
+import "testing"
+
+func TestMsgVersionDecodeRejectsMalformedInput(t *testing.T) {
+	badAgentLength := make([]byte, 123)
+	badAgentLength[116] = 2
+	for _, data := range [][]byte{
+		{},
+		make([]byte, 121),
+		badAgentLength,
+	} {
+		msg := new(MsgVersion)
+		if err := msg.Decode(data); err == nil {
+			t.Errorf("MsgVersion.Decode accepted malformed payload of length %d", len(data))
+		}
+	}
+}
+
+func TestMsgHeadersDecodeRejectsOversizedBatch(t *testing.T) {
+	data := WriteUvarint(maxBlockHeaders + 1)
+	msg := new(MsgHeaders)
+	if err := msg.Decode(data); err == nil {
+		t.Fatal("MsgHeaders.Decode accepted more than the protocol header batch limit")
+	}
+}

--- a/handshake/network.go
+++ b/handshake/network.go
@@ -6,10 +6,13 @@
 
 package handshake
 
+import "math/big"
+
 type Network struct {
 	Name         string
 	Magic        uint32
 	GenesisHash  string
+	PowLimit     *big.Int
 	PowLimitBits uint32
 }
 
@@ -17,5 +20,6 @@ var NetworkMainnet = Network{
 	Name:         "mainnet",
 	Magic:        1533997779,
 	GenesisHash:  "5b6ef2d3c1f3cdcadfd9a030ba1811efdd17740f14e166489760741d075992e0",
+	PowLimit:     CompactToTarget(0x1c00ffff),
 	PowLimitBits: 0x1c00ffff,
 }

--- a/handshake/network.go
+++ b/handshake/network.go
@@ -7,13 +7,15 @@
 package handshake
 
 type Network struct {
-	Name        string
-	Magic       uint32
-	GenesisHash string
+	Name         string
+	Magic        uint32
+	GenesisHash  string
+	PowLimitBits uint32
 }
 
 var NetworkMainnet = Network{
-	Name:        "mainnet",
-	Magic:       1533997779,
-	GenesisHash: "5b6ef2d3c1f3cdcadfd9a030ba1811efdd17740f14e166489760741d075992e0",
+	Name:         "mainnet",
+	Magic:        1533997779,
+	GenesisHash:  "5b6ef2d3c1f3cdcadfd9a030ba1811efdd17740f14e166489760741d075992e0",
+	PowLimitBits: 0x1c00ffff,
 }

--- a/handshake/peer.go
+++ b/handshake/peer.go
@@ -50,19 +50,47 @@ type Peer struct {
 // requested. Difficulty retarget validation still requires more chain history
 // than this peer retains; each header is nevertheless checked for a valid
 // compact target, PoW, and exact parent linkage.
+//
+//nolint:unused // Kept as a single-parent compatibility helper for tests.
 func validateHeaderChain(
 	headers []*BlockHeader,
 	previous [32]byte,
 ) error {
+	return validateHeaderChainFromLocators(headers, [][32]byte{previous})
+}
+
+func validateHeaderChainFromLocators(
+	headers []*BlockHeader,
+	locators [][32]byte,
+) error {
 	if len(headers) > maxBlockHeaders {
 		return fmt.Errorf("too many block headers: %d", len(headers))
 	}
-	expectedPrevious := previous
+	if len(headers) == 0 {
+		return nil
+	}
+	if headers[0] == nil {
+		return errors.New("header 0 is nil")
+	}
+	firstParentMatches := false
+	for _, locator := range locators {
+		if headers[0].PrevBlock == locator {
+			firstParentMatches = true
+			break
+		}
+	}
+	if !firstParentMatches {
+		return fmt.Errorf(
+			"header 0 PrevBlock %x does not match any locator",
+			headers[0].PrevBlock,
+		)
+	}
+	var expectedPrevious [32]byte
 	for idx, header := range headers {
 		if header == nil {
 			return fmt.Errorf("header %d is nil", idx)
 		}
-		if header.PrevBlock != expectedPrevious {
+		if idx > 0 && header.PrevBlock != expectedPrevious {
 			return fmt.Errorf(
 				"header %d PrevBlock %x does not match expected parent %x",
 				idx,
@@ -315,6 +343,9 @@ func (p *Peer) handshake() error {
 		case msg := <-p.handshakeCh:
 			switch msg := msg.(type) {
 			case *MsgVersion:
+				if versionReceived {
+					return errors.New("duplicate version message")
+				}
 				versionReceived = true
 				if !verackSent {
 					if err := p.sendMessage(MessageVerack, nil); err != nil {
@@ -323,6 +354,9 @@ func (p *Peer) handshake() error {
 					verackSent = true
 				}
 			case *MsgVerack:
+				if verackReceived {
+					return errors.New("duplicate verack message")
+				}
 				verackReceived = true
 			default:
 				return fmt.Errorf("unexpected message: %T", msg)
@@ -487,9 +521,9 @@ func (p *Peer) Sync(locator [][32]byte, syncFunc SyncFunc) error {
 					if len(nextLocator) == 0 {
 						return errors.New("sync locator is empty")
 					}
-					if err := validateHeaderChain(
+					if err := validateHeaderChainFromLocators(
 						msgHeaders.Headers,
-						nextLocator[0],
+						nextLocator,
 					); err != nil {
 						return fmt.Errorf("invalid header batch: %w", err)
 					}

--- a/handshake/peer.go
+++ b/handshake/peer.go
@@ -76,16 +76,22 @@ func validateHeaderChainFromLocators(
 			headers[0].PrevBlock,
 		)
 	}
-	powLimit, err := CompactToTargetChecked(network.PowLimitBits)
-	if err != nil {
-		return fmt.Errorf(
-			"invalid network PoW limit 0x%08x: %w",
-			network.PowLimitBits,
-			err,
-		)
-	}
-	if network.PowLimit != nil {
-		powLimit = network.PowLimit
+	// PowLimit is the value actually enforced below, so only derive it from the
+	// compact PowLimitBits when the network does not supply it directly. Doing
+	// the conversion unconditionally would reject a network that configures
+	// PowLimit alone, since CompactToTargetChecked refuses the zero value that
+	// PowLimitBits would then hold.
+	powLimit := network.PowLimit
+	if powLimit == nil {
+		var err error
+		powLimit, err = CompactToTargetChecked(network.PowLimitBits)
+		if err != nil {
+			return fmt.Errorf(
+				"invalid network PoW limit 0x%08x: %w",
+				network.PowLimitBits,
+				err,
+			)
+		}
 	}
 	var expectedPrevious [32]byte
 	for idx, header := range headers {

--- a/handshake/peer.go
+++ b/handshake/peer.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	dialTimeout = 5 * time.Second
+	dialTimeout        = 5 * time.Second
+	peerRequestTimeout = 5 * time.Second
 
 	protocolVersion            = 1
 	protocolUserAgent          = "/cdnsd/"
@@ -43,6 +44,38 @@ type Peer struct {
 	blockCh      chan Message
 	addrCh       chan Message
 	proofCh      chan Message
+}
+
+// validateHeaderChain verifies the bounded header batch before any blocks are
+// requested. Difficulty retarget validation still requires more chain history
+// than this peer retains; each header is nevertheless checked for a valid
+// compact target, PoW, and exact parent linkage.
+func validateHeaderChain(
+	headers []*BlockHeader,
+	previous [32]byte,
+) error {
+	if len(headers) > maxBlockHeaders {
+		return fmt.Errorf("too many block headers: %d", len(headers))
+	}
+	expectedPrevious := previous
+	for idx, header := range headers {
+		if header == nil {
+			return fmt.Errorf("header %d is nil", idx)
+		}
+		if header.PrevBlock != expectedPrevious {
+			return fmt.Errorf(
+				"header %d PrevBlock %x does not match expected parent %x",
+				idx,
+				header.PrevBlock,
+				expectedPrevious,
+			)
+		}
+		if err := header.ValidatePoW(); err != nil {
+			return fmt.Errorf("header %d PoW validation failed: %w", idx, err)
+		}
+		expectedPrevious = header.Hash()
+	}
+	return nil
 }
 
 // NewPeer returns a new Peer using an existing connection (if provided) and the specified network magic. If a connection is provided,
@@ -269,33 +302,38 @@ func (p *Peer) handshake() error {
 	if err := p.sendMessage(MessageVersion, versionMsg); err != nil {
 		return err
 	}
-	// Wait for Verack response
-	select {
-	case msg := <-p.handshakeCh:
-		if _, ok := msg.(*MsgVerack); !ok {
-			return fmt.Errorf("unexpected message: %T", msg)
+	// Version and Verack may arrive in either order. Send our Verack as soon
+	// as the peer's Version arrives so peers that wait for it before sending
+	// their Verack do not deadlock.
+	versionReceived := false
+	verackReceived := false
+	verackSent := false
+	timeout := time.NewTimer(peerRequestTimeout)
+	defer timeout.Stop()
+	for !versionReceived || !verackReceived {
+		select {
+		case msg := <-p.handshakeCh:
+			switch msg := msg.(type) {
+			case *MsgVersion:
+				versionReceived = true
+				if !verackSent {
+					if err := p.sendMessage(MessageVerack, nil); err != nil {
+						return err
+					}
+					verackSent = true
+				}
+			case *MsgVerack:
+				verackReceived = true
+			default:
+				return fmt.Errorf("unexpected message: %T", msg)
+			}
+		case err := <-p.errorCh:
+			return fmt.Errorf("handshake failed: %w", err)
+		case <-p.doneCh:
+			return errors.New("connection has shut down")
+		case <-timeout.C:
+			return errors.New("handshake timed out")
 		}
-	case err := <-p.errorCh:
-		return fmt.Errorf("handshake failed: %w", err)
-	case <-time.After(1 * time.Second):
-		return errors.New("handshake timed out")
-	}
-	// Wait for Version from peer
-	select {
-	case msg := <-p.handshakeCh:
-		if _, ok := msg.(*MsgVersion); !ok {
-			return fmt.Errorf("unexpected message: %T", msg)
-		}
-	case err := <-p.errorCh:
-		return fmt.Errorf("handshake failed: %w", err)
-	case <-p.doneCh:
-		return errors.New("connection has shut down")
-	case <-time.After(1 * time.Second):
-		return errors.New("handshake timed out")
-	}
-	// Send Verack
-	if err := p.sendMessage(MessageVerack, nil); err != nil {
-		return err
 	}
 	return nil
 }
@@ -315,7 +353,7 @@ func (p *Peer) GetPeers() ([]NetAddress, error) {
 		return msgAddr.Peers, nil
 	case <-p.doneCh:
 		return nil, errors.New("connection has shut down")
-	case <-time.After(5 * time.Second):
+	case <-time.After(peerRequestTimeout):
 		return nil, errors.New("timed out")
 	}
 }
@@ -342,7 +380,7 @@ func (p *Peer) GetHeaders(
 		return msgHeaders.Headers, nil
 	case <-p.doneCh:
 		return nil, errors.New("connection has shut down")
-	case <-time.After(5 * time.Second):
+	case <-time.After(peerRequestTimeout):
 		return nil, errors.New("timed out")
 	}
 }
@@ -367,7 +405,7 @@ func (p *Peer) GetProof(name string, rootHash [32]byte) (*Proof, error) {
 		return msgProof.Proof, nil
 	case <-p.doneCh:
 		return nil, errors.New("connection has shut down")
-	case <-time.After(5 * time.Second):
+	case <-time.After(peerRequestTimeout):
 		return nil, errors.New("timed out")
 	}
 }
@@ -395,7 +433,7 @@ func (p *Peer) GetBlock(hash [32]byte) (*Block, error) {
 		return msgBlock.Block, nil
 	case <-p.doneCh:
 		return nil, errors.New("connection has shut down")
-	case <-time.After(5 * time.Second):
+	case <-time.After(peerRequestTimeout):
 		return nil, errors.New("timed out")
 	}
 }
@@ -427,7 +465,6 @@ func (p *Peer) Sync(locator [][32]byte, syncFunc SyncFunc) error {
 		err := func() error {
 			nextLocator := locator
 			reachedTip := false
-		syncLoop:
 			for {
 				// Explicitly request headers on initial or catch-up sync
 				if !reachedTip {
@@ -447,16 +484,33 @@ func (p *Peer) Sync(locator [][32]byte, syncFunc SyncFunc) error {
 					if !ok {
 						return fmt.Errorf("unexpected message: %T", msg)
 					}
+					if len(nextLocator) == 0 {
+						return errors.New("sync locator is empty")
+					}
+					if err := validateHeaderChain(
+						msgHeaders.Headers,
+						nextLocator[0],
+					); err != nil {
+						return fmt.Errorf("invalid header batch: %w", err)
+					}
 					// Fetch block for each header
 					for _, header := range msgHeaders.Headers {
-						// Switch back to initial sync mode if we get header that doesn't fit on last known block
-						if nextLocator[0] != header.PrevBlock {
-							reachedTip = false
-							continue syncLoop
-						}
 						blk, err := p.GetBlock(header.Hash())
 						if err != nil {
 							return err
+						}
+						if blk == nil {
+							return errors.New("peer returned a nil block")
+						}
+						if blk.Header != *header {
+							return fmt.Errorf(
+								"peer returned block header %x for requested header %x",
+								blk.Hash(),
+								header.Hash(),
+							)
+						}
+						if err := blk.ValidatePoW(); err != nil {
+							return fmt.Errorf("fetched block PoW validation failed: %w", err)
 						}
 						// Call user callback with block
 						if err := syncFunc(blk); err != nil {

--- a/handshake/peer.go
+++ b/handshake/peer.go
@@ -48,21 +48,6 @@ type Peer struct {
 	proofCh      chan Message
 }
 
-// validateHeaderChain verifies the bounded header batch before any blocks are
-// requested. Difficulty retarget validation still requires more chain history
-// than this peer retains; each header is nevertheless checked for a valid
-// compact target, PoW, and exact parent linkage.
-func validateHeaderChain(
-	headers []*BlockHeader,
-	previous [32]byte,
-) error {
-	return validateHeaderChainFromLocators(
-		headers,
-		[][32]byte{previous},
-		NetworkMainnet.PowLimitBits,
-	)
-}
-
 func validateHeaderChainFromLocators(
 	headers []*BlockHeader,
 	locators [][32]byte,

--- a/handshake/peer.go
+++ b/handshake/peer.go
@@ -92,6 +92,15 @@ func validateHeaderChainFromLocators(
 				err,
 			)
 		}
+	} else if powLimit.Sign() <= 0 || powLimit.BitLen() > 256 {
+		// An explicit limit skips the compact decoder, so it gets the same
+		// bounds check the decoder would have applied. A non-positive limit
+		// would reject every header and stall sync; one wider than 256 bits
+		// would not constrain any hash and would silently disable the gate.
+		return fmt.Errorf(
+			"invalid network PoW limit %s: must be positive and fit in 256 bits",
+			powLimit,
+		)
 	}
 	var expectedPrevious [32]byte
 	for idx, header := range headers {

--- a/handshake/peer.go
+++ b/handshake/peer.go
@@ -51,7 +51,7 @@ type Peer struct {
 func validateHeaderChainFromLocators(
 	headers []*BlockHeader,
 	locators [][32]byte,
-	powLimitBits uint32,
+	network Network,
 ) error {
 	if len(headers) > maxBlockHeaders {
 		return fmt.Errorf("too many block headers: %d", len(headers))
@@ -76,9 +76,16 @@ func validateHeaderChainFromLocators(
 			headers[0].PrevBlock,
 		)
 	}
-	powLimit, err := CompactToTargetChecked(powLimitBits)
+	powLimit, err := CompactToTargetChecked(network.PowLimitBits)
 	if err != nil {
-		return fmt.Errorf("invalid network PoW limit 0x%08x: %w", powLimitBits, err)
+		return fmt.Errorf(
+			"invalid network PoW limit 0x%08x: %w",
+			network.PowLimitBits,
+			err,
+		)
+	}
+	if network.PowLimit != nil {
+		powLimit = network.PowLimit
 	}
 	var expectedPrevious [32]byte
 	for idx, header := range headers {
@@ -526,7 +533,7 @@ func (p *Peer) Sync(locator [][32]byte, syncFunc SyncFunc) error {
 					if err := validateHeaderChainFromLocators(
 						msgHeaders.Headers,
 						nextLocator,
-						p.network.PowLimitBits,
+						p.network,
 					); err != nil {
 						if errors.Is(err, errHeaderChainDoesNotExtend) {
 							reachedTip = false

--- a/handshake/peer.go
+++ b/handshake/peer.go
@@ -18,6 +18,8 @@ import (
 	"time"
 )
 
+var errHeaderChainDoesNotExtend = errors.New("header batch does not extend current locator")
+
 const (
 	dialTimeout        = 5 * time.Second
 	peerRequestTimeout = 5 * time.Second
@@ -50,18 +52,21 @@ type Peer struct {
 // requested. Difficulty retarget validation still requires more chain history
 // than this peer retains; each header is nevertheless checked for a valid
 // compact target, PoW, and exact parent linkage.
-//
-//nolint:unused // Kept as a single-parent compatibility helper for tests.
 func validateHeaderChain(
 	headers []*BlockHeader,
 	previous [32]byte,
 ) error {
-	return validateHeaderChainFromLocators(headers, [][32]byte{previous})
+	return validateHeaderChainFromLocators(
+		headers,
+		[][32]byte{previous},
+		NetworkMainnet.PowLimitBits,
+	)
 }
 
 func validateHeaderChainFromLocators(
 	headers []*BlockHeader,
 	locators [][32]byte,
+	powLimitBits uint32,
 ) error {
 	if len(headers) > maxBlockHeaders {
 		return fmt.Errorf("too many block headers: %d", len(headers))
@@ -81,9 +86,14 @@ func validateHeaderChainFromLocators(
 	}
 	if !firstParentMatches {
 		return fmt.Errorf(
-			"header 0 PrevBlock %x does not match any locator",
+			"%w: header 0 PrevBlock %x does not match any locator",
+			errHeaderChainDoesNotExtend,
 			headers[0].PrevBlock,
 		)
+	}
+	powLimit, err := CompactToTargetChecked(powLimitBits)
+	if err != nil {
+		return fmt.Errorf("invalid network PoW limit 0x%08x: %w", powLimitBits, err)
 	}
 	var expectedPrevious [32]byte
 	for idx, header := range headers {
@@ -97,6 +107,13 @@ func validateHeaderChainFromLocators(
 				header.PrevBlock,
 				expectedPrevious,
 			)
+		}
+		headerTarget, err := CompactToTargetChecked(header.Bits)
+		if err != nil {
+			return fmt.Errorf("header %d has invalid target: %w", idx, err)
+		}
+		if headerTarget.Cmp(powLimit) > 0 {
+			return fmt.Errorf("header %d target exceeds network PoW limit", idx)
 		}
 		if err := header.ValidatePoW(); err != nil {
 			return fmt.Errorf("header %d PoW validation failed: %w", idx, err)
@@ -524,7 +541,12 @@ func (p *Peer) Sync(locator [][32]byte, syncFunc SyncFunc) error {
 					if err := validateHeaderChainFromLocators(
 						msgHeaders.Headers,
 						nextLocator,
+						p.network.PowLimitBits,
 					); err != nil {
+						if errors.Is(err, errHeaderChainDoesNotExtend) {
+							reachedTip = false
+							continue
+						}
 						return fmt.Errorf("invalid header batch: %w", err)
 					}
 					// Fetch block for each header

--- a/handshake/peer_internal_test.go
+++ b/handshake/peer_internal_test.go
@@ -6,7 +6,10 @@
 
 package handshake
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func validateHeaderChain(headers []*BlockHeader, previous [32]byte) error {
 	return validateHeaderChainFromLocators(
@@ -40,5 +43,56 @@ func TestValidateHeaderChainRejectsTargetAboveNetworkLimit(t *testing.T) {
 		[32]byte{},
 	); err == nil {
 		t.Fatal("validateHeaderChain accepted a target above the network limit")
+	}
+}
+
+// TestValidateHeaderChainUsesExplicitPowLimit covers a network that configures
+// PowLimit directly and leaves the compact PowLimitBits at its zero value.
+// PowLimit is what the per-header check enforces, so deriving the limit from
+// PowLimitBits unconditionally would reject every header batch on such a
+// network: CompactToTargetChecked refuses a zero encoding.
+func TestValidateHeaderChainUsesExplicitPowLimit(t *testing.T) {
+	network := Network{
+		Name:     "explicit-powlimit",
+		PowLimit: CompactToTarget(0x1d00ffff),
+		// PowLimitBits deliberately left zero.
+	}
+	// A target at the configured limit must be accepted by the limit check.
+	// ValidatePoW still applies, so assert on the limit error specifically
+	// rather than on overall success.
+	err := validateHeaderChainFromLocators(
+		[]*BlockHeader{{Bits: 0x1d00ffff}},
+		[][32]byte{{}},
+		network,
+	)
+	if err != nil && strings.Contains(err.Error(), "invalid network PoW limit") {
+		t.Fatalf("explicit PowLimit was ignored in favour of zero PowLimitBits: %v", err)
+	}
+	if err != nil && strings.Contains(err.Error(), "exceeds network PoW limit") {
+		t.Fatalf("target at the configured limit was rejected: %v", err)
+	}
+
+	// A target above the configured limit must still be refused.
+	err = validateHeaderChainFromLocators(
+		[]*BlockHeader{{Bits: 0x1e00ffff}},
+		[][32]byte{{}},
+		network,
+	)
+	if err == nil || !strings.Contains(err.Error(), "exceeds network PoW limit") {
+		t.Fatalf("target above the configured PowLimit: want a limit error, got %v", err)
+	}
+}
+
+// TestValidateHeaderChainRejectsUnusableNetworkPowLimit is the companion: with
+// neither PowLimit nor a valid PowLimitBits there is no limit to enforce, so
+// validation must fail loudly rather than proceed without a ceiling.
+func TestValidateHeaderChainRejectsUnusableNetworkPowLimit(t *testing.T) {
+	err := validateHeaderChainFromLocators(
+		[]*BlockHeader{{Bits: 0x1d00ffff}},
+		[][32]byte{{}},
+		Network{Name: "no-powlimit"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "invalid network PoW limit") {
+		t.Fatalf("network with no usable PoW limit: want an invalid-limit error, got %v", err)
 	}
 }

--- a/handshake/peer_internal_test.go
+++ b/handshake/peer_internal_test.go
@@ -25,3 +25,12 @@ func TestValidateHeaderChainRejectsNilHeader(t *testing.T) {
 		t.Fatal("validateHeaderChain accepted a nil header")
 	}
 }
+
+func TestValidateHeaderChainRejectsTargetAboveNetworkLimit(t *testing.T) {
+	if err := validateHeaderChain(
+		[]*BlockHeader{{Bits: 0x1d00ffff}},
+		[32]byte{},
+	); err == nil {
+		t.Fatal("validateHeaderChain accepted a target above the network limit")
+	}
+}

--- a/handshake/peer_internal_test.go
+++ b/handshake/peer_internal_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Blink Labs Software
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package handshake
+
+import "testing"
+
+func TestValidateHeaderChainRejectsBrokenParent(t *testing.T) {
+	var previous [32]byte
+	var wrongParent [32]byte
+	wrongParent[0] = 1
+	if err := validateHeaderChain(
+		[]*BlockHeader{{PrevBlock: wrongParent}},
+		previous,
+	); err == nil {
+		t.Fatal("validateHeaderChain accepted a header with the wrong parent")
+	}
+}
+
+func TestValidateHeaderChainRejectsNilHeader(t *testing.T) {
+	if err := validateHeaderChain([]*BlockHeader{nil}, [32]byte{}); err == nil {
+		t.Fatal("validateHeaderChain accepted a nil header")
+	}
+}

--- a/handshake/peer_internal_test.go
+++ b/handshake/peer_internal_test.go
@@ -12,7 +12,7 @@ func validateHeaderChain(headers []*BlockHeader, previous [32]byte) error {
 	return validateHeaderChainFromLocators(
 		headers,
 		[][32]byte{previous},
-		NetworkMainnet.PowLimitBits,
+		NetworkMainnet,
 	)
 }
 

--- a/handshake/peer_internal_test.go
+++ b/handshake/peer_internal_test.go
@@ -8,6 +8,14 @@ package handshake
 
 import "testing"
 
+func validateHeaderChain(headers []*BlockHeader, previous [32]byte) error {
+	return validateHeaderChainFromLocators(
+		headers,
+		[][32]byte{previous},
+		NetworkMainnet.PowLimitBits,
+	)
+}
+
 func TestValidateHeaderChainRejectsBrokenParent(t *testing.T) {
 	var previous [32]byte
 	var wrongParent [32]byte

--- a/handshake/peer_internal_test.go
+++ b/handshake/peer_internal_test.go
@@ -7,6 +7,7 @@
 package handshake
 
 import (
+	"math/big"
 	"strings"
 	"testing"
 )
@@ -94,5 +95,30 @@ func TestValidateHeaderChainRejectsUnusableNetworkPowLimit(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "invalid network PoW limit") {
 		t.Fatalf("network with no usable PoW limit: want an invalid-limit error, got %v", err)
+	}
+}
+
+// TestValidateHeaderChainRejectsInvalidExplicitPowLimit covers a malformed
+// explicit PowLimit. It bypasses the compact decoder, so it needs the same
+// bounds check: a non-positive limit rejects every header and stalls sync, and
+// one wider than 256 bits cannot constrain any hash, silently disabling the
+// gate that stops a peer choosing its own difficulty.
+func TestValidateHeaderChainRejectsInvalidExplicitPowLimit(t *testing.T) {
+	oversized := new(big.Int).Lsh(big.NewInt(1), 256)
+	for name, limit := range map[string]*big.Int{
+		"zero":      big.NewInt(0),
+		"negative":  big.NewInt(-1),
+		"oversized": oversized,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := validateHeaderChainFromLocators(
+				[]*BlockHeader{{Bits: 0x1d00ffff}},
+				[][32]byte{{}},
+				Network{Name: "bad-powlimit", PowLimit: limit},
+			)
+			if err == nil || !strings.Contains(err.Error(), "invalid network PoW limit") {
+				t.Fatalf("PowLimit %s: want an invalid-limit error, got %v", limit, err)
+			}
+		})
 	}
 }

--- a/handshake/peer_test.go
+++ b/handshake/peer_test.go
@@ -7,9 +7,12 @@
 package handshake
 
 import (
+	"errors"
 	"io"
 	"net"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestPeerHandshakeAcceptsVersionBeforeVerack(t *testing.T) {
@@ -139,4 +142,220 @@ func writePeerMessage(conn net.Conn, msgType uint8, msg Message) error {
 	}
 	_, err = conn.Write(raw)
 	return err
+}
+
+// newSyncTestPeer returns a handshaked Peer along with the remote end of its
+// connection, so a test can drive Sync from the peer side.
+func newSyncTestPeer(t *testing.T) (*Peer, net.Conn) {
+	t.Helper()
+	client, server := net.Pipe()
+	type peerResult struct {
+		peer *Peer
+		err  error
+	}
+	peerCh := make(chan peerResult, 1)
+	go func() {
+		peer, err := NewPeer(client, NetworkMainnet)
+		peerCh <- peerResult{peer: peer, err: err}
+	}()
+	if err := server.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	if _, err := readPeerMessage(server); err != nil {
+		t.Fatalf("read client version: %v", err)
+	}
+	peerVersion := &MsgVersion{
+		Version:  1,
+		Agent:    "/handshaked/",
+		Remote:   NetAddress{Host: net.ParseIP("0.0.0.0")},
+		NoRelay:  true,
+		Services: protocolServicesNoServices,
+	}
+	if err := writePeerMessage(server, MessageVersion, peerVersion); err != nil {
+		t.Fatalf("write peer version: %v", err)
+	}
+	msg, err := readPeerMessage(server)
+	if err != nil {
+		t.Fatalf("read client verack: %v", err)
+	}
+	if _, ok := msg.(*MsgVerack); !ok {
+		t.Fatalf("client sent %T after peer version, want *MsgVerack", msg)
+	}
+	if err := writePeerMessage(server, MessageVerack, nil); err != nil {
+		t.Fatalf("write peer verack: %v", err)
+	}
+	result := <-peerCh
+	if result.err != nil {
+		t.Fatalf("NewPeer() error = %v", result.err)
+	}
+	if result.peer == nil {
+		t.Fatal("NewPeer() returned a nil peer")
+	}
+	return result.peer, server
+}
+
+// readPeerFrame reads one wire frame and returns its message type with a
+// best-effort decode. Sync sends SendHeaders, which decodeMessage does not
+// support, so the frame type has to be observable without a decoded message.
+func readPeerFrame(conn net.Conn) (uint8, Message, error) {
+	headerBytes := make([]byte, messageHeaderLength)
+	if _, err := io.ReadFull(conn, headerBytes); err != nil {
+		return 0, nil, err
+	}
+	header := new(msgHeader)
+	if err := header.Decode(headerBytes); err != nil {
+		return 0, nil, err
+	}
+	payload := make([]byte, header.PayloadLength)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		return 0, nil, err
+	}
+	msg, err := decodeMessage(header, payload)
+	var unsupportedErr UnsupportedMessageTypeError
+	if err != nil && !errors.As(err, &unsupportedErr) {
+		return header.MessageType, nil, err
+	}
+	return header.MessageType, msg, nil
+}
+
+// expectGetHeaders requires the next frame to be a GetHeaders for the given
+// locator. A closed connection surfaces here as a read error, which is how a
+// Sync teardown is distinguished from an in-protocol re-request.
+func expectGetHeaders(t *testing.T, conn net.Conn, locator [][32]byte) {
+	t.Helper()
+	msgType, msg, err := readPeerFrame(conn)
+	if err != nil {
+		t.Fatalf("read GetHeaders: %v", err)
+	}
+	if msgType != MessageGetHeaders {
+		t.Fatalf("frame type = %d, want MessageGetHeaders (%d)", msgType, MessageGetHeaders)
+	}
+	getHeaders, ok := msg.(*MsgGetHeaders)
+	if !ok {
+		t.Fatalf("frame decoded to %T, want *MsgGetHeaders", msg)
+	}
+	if len(getHeaders.Locator) != len(locator) {
+		t.Fatalf("GetHeaders locator length = %d, want %d", len(getHeaders.Locator), len(locator))
+	}
+	for idx := range locator {
+		if getHeaders.Locator[idx] != locator[idx] {
+			t.Fatalf(
+				"GetHeaders locator[%d] = %x, want %x",
+				idx,
+				getHeaders.Locator[idx],
+				locator[idx],
+			)
+		}
+	}
+}
+
+// expectSendHeadersThenGetHeaders consumes the two frames Sync always emits
+// before it waits for a header batch.
+func expectSendHeadersThenGetHeaders(
+	t *testing.T,
+	conn net.Conn,
+	locator [][32]byte,
+) {
+	t.Helper()
+	msgType, _, err := readPeerFrame(conn)
+	if err != nil {
+		t.Fatalf("read SendHeaders: %v", err)
+	}
+	if msgType != MessageSendHeaders {
+		t.Fatalf("frame type = %d, want MessageSendHeaders (%d)", msgType, MessageSendHeaders)
+	}
+	expectGetHeaders(t, conn, locator)
+}
+
+// TestSyncRecoversWhenHeaderBatchDoesNotExtendLocator pins the in-protocol
+// recovery path: a batch whose first header does not build on the current
+// locator is not a validation failure, it means we asked from the wrong point.
+// Sync must drop back to catch-up mode and re-request headers rather than
+// pushing an error and closing the connection, which would force a full
+// reconnect and re-handshake on every reorg.
+func TestSyncRecoversWhenHeaderBatchDoesNotExtendLocator(t *testing.T) {
+	peer, server := newSyncTestPeer(t)
+	defer server.Close()
+
+	locatorHash := [32]byte{0xaa}
+	locator := [][32]byte{locatorHash}
+	// Sync writes SendHeaders synchronously on an unbuffered pipe, so it has
+	// to run off the goroutine that drains the pipe.
+	syncErrCh := make(chan error, 1)
+	go func() {
+		syncErrCh <- peer.Sync(locator, func(*Block) error {
+			return errors.New(
+				"syncFunc called for a batch that does not extend the locator",
+			)
+		})
+	}()
+	expectSendHeadersThenGetHeaders(t, server, locator)
+	if err := <-syncErrCh; err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	// First header builds on something else entirely.
+	if err := writePeerMessage(server, MessageHeaders, &MsgHeaders{
+		Headers: []*BlockHeader{{PrevBlock: [32]byte{0xbb}}},
+	}); err != nil {
+		t.Fatalf("write headers: %v", err)
+	}
+
+	// The recovery is observable as a second GetHeaders for the same locator.
+	expectGetHeaders(t, server, locator)
+
+	select {
+	case err := <-peer.ErrorChan():
+		t.Fatalf("Sync reported a fatal error for a recoverable batch: %v", err)
+	case <-peer.DoneChan():
+		t.Fatal("Sync closed the peer for a recoverable batch")
+	default:
+	}
+	_ = peer.Close()
+}
+
+// TestSyncStopsWhenHeaderBatchTargetExceedsNetworkPowLimit is the companion
+// negative case. The batch does extend the locator, so the recovery path must
+// not swallow it: a header claiming a target easier than the network PoW limit
+// is a validation failure and has to tear the peer down.
+func TestSyncStopsWhenHeaderBatchTargetExceedsNetworkPowLimit(t *testing.T) {
+	peer, server := newSyncTestPeer(t)
+	defer server.Close()
+
+	locatorHash := [32]byte{0xaa}
+	locator := [][32]byte{locatorHash}
+	syncErrCh := make(chan error, 1)
+	go func() {
+		syncErrCh <- peer.Sync(locator, func(*Block) error {
+			return errors.New("syncFunc called for a batch that fails validation")
+		})
+	}()
+	expectSendHeadersThenGetHeaders(t, server, locator)
+	if err := <-syncErrCh; err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	// mainnet PowLimit is 0x1c00ffff, so 0x1d00ffff is 256 times easier.
+	if err := writePeerMessage(server, MessageHeaders, &MsgHeaders{
+		Headers: []*BlockHeader{{PrevBlock: locatorHash, Bits: 0x1d00ffff}},
+	}); err != nil {
+		t.Fatalf("write headers: %v", err)
+	}
+
+	select {
+	case err := <-peer.ErrorChan():
+		if !strings.Contains(err.Error(), "invalid header batch") {
+			t.Fatalf("Sync error = %v, want an invalid header batch error", err)
+		}
+		if !strings.Contains(err.Error(), "exceeds network PoW limit") {
+			t.Fatalf("Sync error = %v, want a network PoW limit error", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Sync did not reject a header batch above the network PoW limit")
+	}
+	select {
+	case <-peer.DoneChan():
+	case <-time.After(15 * time.Second):
+		t.Fatal("Sync did not close the peer after a validation failure")
+	}
 }

--- a/handshake/peer_test.go
+++ b/handshake/peer_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 Blink Labs Software
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+package handshake
+
+import (
+	"io"
+	"net"
+	"testing"
+)
+
+func TestPeerHandshakeAcceptsVersionBeforeVerack(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+
+	peerCh := make(chan struct {
+		peer *Peer
+		err  error
+	}, 1)
+	go func() {
+		peer, err := NewPeer(client, NetworkMainnet)
+		peerCh <- struct {
+			peer *Peer
+			err  error
+		}{peer: peer, err: err}
+	}()
+
+	if _, err := readPeerMessage(server); err != nil {
+		t.Fatalf("read client version: %v", err)
+	}
+	peerVersion := &MsgVersion{
+		Version:  1,
+		Agent:    "/handshaked/",
+		Remote:   NetAddress{Host: net.ParseIP("0.0.0.0")},
+		NoRelay:  true,
+		Services: protocolServicesNoServices,
+	}
+	if err := writePeerMessage(server, MessageVersion, peerVersion); err != nil {
+		t.Fatalf("write peer version: %v", err)
+	}
+	msg, err := readPeerMessage(server)
+	if err != nil {
+		t.Fatalf("read client verack: %v", err)
+	}
+	if _, ok := msg.(*MsgVerack); !ok {
+		t.Fatalf("client sent %T after peer version, want *MsgVerack", msg)
+	}
+	if err := writePeerMessage(server, MessageVerack, nil); err != nil {
+		t.Fatalf("write peer verack: %v", err)
+	}
+
+	result := <-peerCh
+	if result.err != nil {
+		t.Fatalf("NewPeer() error = %v", result.err)
+	}
+	if result.peer == nil {
+		t.Fatal("NewPeer() returned a nil peer")
+	}
+	_ = result.peer.Close()
+}
+
+func TestPeerHandshakeAcceptsVerackBeforeVersion(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+
+	peerCh := make(chan struct {
+		peer *Peer
+		err  error
+	}, 1)
+	go func() {
+		peer, err := NewPeer(client, NetworkMainnet)
+		peerCh <- struct {
+			peer *Peer
+			err  error
+		}{peer: peer, err: err}
+	}()
+
+	if _, err := readPeerMessage(server); err != nil {
+		t.Fatalf("read client version: %v", err)
+	}
+	if err := writePeerMessage(server, MessageVerack, nil); err != nil {
+		t.Fatalf("write peer verack: %v", err)
+	}
+	peerVersion := &MsgVersion{
+		Version:  1,
+		Agent:    "/handshaked/",
+		Remote:   NetAddress{Host: net.ParseIP("0.0.0.0")},
+		NoRelay:  true,
+		Services: protocolServicesNoServices,
+	}
+	if err := writePeerMessage(server, MessageVersion, peerVersion); err != nil {
+		t.Fatalf("write peer version: %v", err)
+	}
+	msg, err := readPeerMessage(server)
+	if err != nil {
+		t.Fatalf("read client verack: %v", err)
+	}
+	if _, ok := msg.(*MsgVerack); !ok {
+		t.Fatalf("client sent %T after peer version, want *MsgVerack", msg)
+	}
+
+	result := <-peerCh
+	if result.err != nil {
+		t.Fatalf("NewPeer() error = %v", result.err)
+	}
+	if result.peer == nil {
+		t.Fatal("NewPeer() returned a nil peer")
+	}
+	_ = result.peer.Close()
+}
+
+func readPeerMessage(conn net.Conn) (Message, error) {
+	headerBytes := make([]byte, messageHeaderLength)
+	if _, err := io.ReadFull(conn, headerBytes); err != nil {
+		return nil, err
+	}
+	header := new(msgHeader)
+	if err := header.Decode(headerBytes); err != nil {
+		return nil, err
+	}
+	payload := make([]byte, header.PayloadLength)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		return nil, err
+	}
+	return decodeMessage(header, payload)
+}
+
+func writePeerMessage(conn net.Conn, msgType uint8, msg Message) error {
+	var payload []byte
+	if msg != nil {
+		payload = msg.Encode()
+	}
+	raw, err := encodeMessage(msgType, payload, NetworkMainnet.Magic)
+	if err != nil {
+		return err
+	}
+	_, err = conn.Write(raw)
+	return err
+}

--- a/handshake/pow.go
+++ b/handshake/pow.go
@@ -42,6 +42,13 @@ func CompactToTarget(bits uint32) *big.Int {
 // cannot be used for proof-of-work. Handshake's consensus verifier accepts
 // positive targets that fit in 256 bits; it does not accept a negative, zero,
 // overflowing, or non-canonical encoding.
+//
+// Rejecting non-canonical encodings is stricter than hsd's decode-side rules,
+// which accept any compact form that decodes to a usable target. It cannot
+// reject a real block: the retarget algorithm computes a target and encodes it,
+// and that encoding is canonical by construction, so no honestly-produced
+// header carries a non-canonical Bits value. The stricter rule only removes
+// encoding freedom from a peer feeding us fabricated headers.
 func CompactToTargetChecked(bits uint32) (*big.Int, error) {
 	if bits&0x00800000 != 0 {
 		return nil, errCompactTargetNegative

--- a/handshake/pow.go
+++ b/handshake/pow.go
@@ -7,13 +7,25 @@
 package handshake
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
+)
+
+var (
+	errCompactTargetZero         = errors.New("compact target is zero")
+	errCompactTargetNegative     = errors.New("compact target is negative")
+	errCompactTargetOverflow     = errors.New("compact target exceeds 256 bits")
+	errCompactTargetNonCanonical = errors.New("compact target is not canonical")
 )
 
 // CompactToTarget converts a Bitcoin compact (nBits) value to a
 // 256-bit target. The first byte is the exponent, the next 3
 // bytes are the mantissa. Target = mantissa * 2^(8*(exp-3)).
+//
+// This function retains the permissive conversion behavior for callers that
+// need to inspect an encoded value. Consensus-sensitive code must use
+// CompactToTargetChecked instead.
 func CompactToTarget(bits uint32) *big.Int {
 	exp := bits >> 24
 	mantissa := bits & 0x007fffff
@@ -26,12 +38,69 @@ func CompactToTarget(bits uint32) *big.Int {
 	return target
 }
 
-// ValidatePoW checks that the block hash satisfies the
-// proof-of-work target derived from the header Bits field.
-// The block hash (big-endian) must be <= target.
-func (b *Block) ValidatePoW() error {
-	target := CompactToTarget(b.Header.Bits)
-	hash := b.Hash()
+// CompactToTargetChecked converts a compact target and rejects encodings that
+// cannot be used for proof-of-work. Handshake's consensus verifier accepts
+// positive targets that fit in 256 bits; it does not accept a negative, zero,
+// overflowing, or non-canonical encoding.
+func CompactToTargetChecked(bits uint32) (*big.Int, error) {
+	if bits&0x00800000 != 0 {
+		return nil, errCompactTargetNegative
+	}
+	mantissa := bits & 0x007fffff
+	if mantissa == 0 {
+		return nil, errCompactTargetZero
+	}
+	target := CompactToTarget(bits)
+	if target.Sign() <= 0 {
+		return nil, errCompactTargetZero
+	}
+	if target.BitLen() > 256 {
+		return nil, errCompactTargetOverflow
+	}
+	if targetToCompact(target) != bits {
+		return nil, errCompactTargetNonCanonical
+	}
+	return target, nil
+}
+
+// targetToCompact returns the canonical compact representation used by
+// Handshake for a positive target.
+func targetToCompact(target *big.Int) uint32 {
+	if target.Sign() <= 0 {
+		return 0
+	}
+
+	exponent := (target.BitLen() + 7) / 8
+	compact := new(big.Int).Set(target)
+	if exponent <= 3 {
+		compact.Lsh(compact, uint(8*(3-exponent)))
+	} else {
+		compact.Rsh(compact, uint(8*(exponent-3)))
+	}
+	mantissaValue := compact.Uint64()
+	if mantissaValue > uint64(^uint32(0)) || exponent > 0xff {
+		return 0
+	}
+	mantissa := uint32(mantissaValue) // #nosec G115 -- explicitly bounded above.
+	if mantissa&0x00800000 != 0 {
+		mantissa >>= 8
+		exponent++
+	}
+	return uint32(exponent)<<24 | (mantissa & 0x007fffff) // #nosec G115 -- exponent is bounded above.
+}
+
+// ValidatePoW checks that the block hash satisfies the proof-of-work target
+// derived from the header Bits field. The block hash (big-endian) must be <=
+// target.
+func (h *BlockHeader) ValidatePoW() error {
+	if h == nil {
+		return errors.New("cannot validate PoW for nil block header")
+	}
+	target, err := CompactToTargetChecked(h.Bits)
+	if err != nil {
+		return fmt.Errorf("invalid compact target 0x%08x: %w", h.Bits, err)
+	}
+	hash := h.Hash()
 	hashInt := new(big.Int).SetBytes(hash[:])
 	if hashInt.Cmp(target) > 0 {
 		return fmt.Errorf(
@@ -41,4 +110,14 @@ func (b *Block) ValidatePoW() error {
 		)
 	}
 	return nil
+}
+
+// ValidatePoW checks that the block hash satisfies the
+// proof-of-work target derived from the header Bits field.
+// The block hash (big-endian) must be <= target.
+func (b *Block) ValidatePoW() error {
+	if b == nil {
+		return errors.New("cannot validate PoW for nil block")
+	}
+	return b.Header.ValidatePoW()
 }

--- a/handshake/pow_test.go
+++ b/handshake/pow_test.go
@@ -117,3 +117,26 @@ func TestValidatePoWBadBlock(t *testing.T) {
 		)
 	}
 }
+
+func TestValidatePoWRejectsInvalidCompactTargets(t *testing.T) {
+	blockBytes, err := hex.DecodeString(blockTestDefs[0].blockHex)
+	if err != nil {
+		t.Fatalf("unexpected error decoding hex: %s", err)
+	}
+	block, err := handshake.NewBlockFromReader(bytes.NewReader(blockBytes))
+	if err != nil {
+		t.Fatalf("unexpected error deserializing block: %s", err)
+	}
+
+	for _, bits := range []uint32{
+		0x1d000000, // zero target
+		0x1d80ffff, // negative target
+		0x2200ffff, // target wider than 256 bits
+		0x04123400, // non-canonical representation
+	} {
+		block.Header.Bits = bits
+		if err := block.ValidatePoW(); err == nil {
+			t.Errorf("ValidatePoW accepted invalid compact target 0x%08x", bits)
+		}
+	}
+}

--- a/handshake/pow_test.go
+++ b/handshake/pow_test.go
@@ -132,7 +132,7 @@ func TestValidatePoWRejectsInvalidCompactTargets(t *testing.T) {
 		0x1d000000, // zero target
 		0x1d80ffff, // negative target
 		0x2200ffff, // target wider than 256 bits
-		0x04123400, // non-canonical representation
+		0x03001234, // non-canonical representation
 	} {
 		block.Header.Bits = bits
 		if err := block.ValidatePoW(); err == nil {

--- a/internal/indexer/handshake.go
+++ b/internal/indexer/handshake.go
@@ -7,6 +7,8 @@
 package indexer
 
 import (
+	"bytes"
+	"crypto/sha3"
 	"encoding/base32"
 	"encoding/hex"
 	"errors"
@@ -27,6 +29,73 @@ type handshakeState struct {
 	peerBackoffDelay time.Duration
 	lastBlockHash    [32]byte
 	hasLastBlock     bool
+}
+
+// validateHandshakeStateChanges performs all state lookups and resource-data
+// conversion before the block is allowed to mutate persistent state. This is
+// intentionally bounded: State has no transactional block journal, so a
+// database write failure can still leave a partially applied block. Reorgs
+// are therefore detected and rejected by parent-hash continuity, while full
+// rollback remains outside this indexer's current state API.
+func validateHandshakeStateChanges(block *handshake.Block) error {
+	if block == nil {
+		return errors.New("cannot validate a nil Handshake block")
+	}
+	for txIndex, tx := range block.Transactions {
+		for outputIndex, output := range tx.Outputs {
+			cov, err := output.Covenant.CheckedCovenant()
+			if err != nil {
+				return fmt.Errorf(
+					"transaction %d output %d covenant: %w",
+					txIndex,
+					outputIndex,
+					err,
+				)
+			}
+			switch c := cov.(type) {
+			case *handshake.RegisterCovenant:
+				name, err := state.GetState().GetHandshakeNameByHash(c.NameHash)
+				if err != nil {
+					return fmt.Errorf("resolve register name: %w", err)
+				}
+				if _, err := handshakeResourceDataToDomainRecords(
+					name,
+					c.ResourceData,
+				); err != nil {
+					return fmt.Errorf("validate register records: %w", err)
+				}
+			case *handshake.UpdateCovenant:
+				name, err := state.GetState().GetHandshakeNameByHash(c.NameHash)
+				if err != nil {
+					return fmt.Errorf("resolve update name: %w", err)
+				}
+				if _, err := handshakeResourceDataToDomainRecords(
+					name,
+					c.ResourceData,
+				); err != nil {
+					return fmt.Errorf("validate update records: %w", err)
+				}
+			case *handshake.RenewCovenant:
+				if _, err := state.GetState().GetHandshakeNameByHash(c.NameHash); err != nil {
+					return fmt.Errorf("resolve renewal name: %w", err)
+				}
+			case *handshake.TransferCovenant:
+				if _, err := state.GetState().GetHandshakeNameByHash(c.NameHash); err != nil {
+					return fmt.Errorf("resolve transfer name: %w", err)
+				}
+			case *handshake.FinalizeCovenant:
+				nameHash := sha3.Sum256([]byte(c.RawName))
+				if !bytes.Equal(c.NameHash, nameHash[:]) {
+					return errors.New("finalize name hash does not match raw name")
+				}
+			case *handshake.RevokeCovenant:
+				if _, err := state.GetState().GetHandshakeNameByHash(c.NameHash); err != nil {
+					return fmt.Errorf("resolve revoke name: %w", err)
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (i *Indexer) startHandshake(stopCh <-chan struct{}) error {
@@ -200,6 +269,9 @@ func (i *Indexer) handshakeReconnectPeer(stopCh <-chan struct{}) {
 }
 
 func (i *Indexer) handshakeHandleSync(block *handshake.Block) error {
+	if block == nil {
+		return errors.New("received nil Handshake block")
+	}
 	slog.Debug(
 		"synced Handshake block",
 		"hash", fmt.Sprintf("%x", block.Hash()),
@@ -225,11 +297,20 @@ func (i *Indexer) handshakeHandleSync(block *handshake.Block) error {
 			err,
 		)
 	}
+	// Parse every covenant and resolve every existing-state dependency before
+	// applying any output. This prevents malformed later outputs from causing
+	// avoidable partial state application.
+	if err := validateHandshakeStateChanges(block); err != nil {
+		return fmt.Errorf("handshake block state preflight failed: %w", err)
+	}
 	// Process transactions
 	for _, tx := range block.Transactions {
 		// Process outputs
 		for _, output := range tx.Outputs {
-			cov := output.Covenant.Covenant()
+			cov, err := output.Covenant.CheckedCovenant()
+			if err != nil {
+				return fmt.Errorf("decode Handshake covenant: %w", err)
+			}
 			switch c := cov.(type) {
 			case *handshake.OpenCovenant:
 				if err := state.GetState().AddHandshakeName(c.RawName); err != nil {

--- a/internal/indexer/handshake.go
+++ b/internal/indexer/handshake.go
@@ -31,71 +31,115 @@ type handshakeState struct {
 	hasLastBlock     bool
 }
 
-// validateHandshakeStateChanges performs all state lookups and resource-data
-// conversion before the block is allowed to mutate persistent state. This is
-// intentionally bounded: State has no transactional block journal, so a
-// database write failure can still leave a partially applied block. Reorgs
-// are therefore detected and rejected by parent-hash continuity, while full
-// rollback remains outside this indexer's current state API.
-func validateHandshakeStateChanges(block *handshake.Block) error {
+type handshakeOutputValidation struct {
+	covenant handshake.Covenant
+	name     string
+	records  []state.DomainRecord
+}
+
+type handshakeBlockPreflight [][]handshakeOutputValidation
+
+// validateHandshakeStateChanges decodes each covenant and resolves all state
+// dependencies once, in block order. Names created earlier in the block are
+// kept in an in-memory overlay so later outputs can reference them without
+// requiring a persistent write during preflight.
+func validateHandshakeStateChanges(
+	block *handshake.Block,
+) (handshakeBlockPreflight, error) {
 	if block == nil {
-		return errors.New("cannot validate a nil Handshake block")
+		return nil, errors.New("cannot validate a nil Handshake block")
+	}
+	preflight := make(handshakeBlockPreflight, len(block.Transactions))
+	knownNames := make(map[string]string)
+	rememberName := func(name string) {
+		nameHash := sha3.Sum256([]byte(name))
+		knownNames[string(nameHash[:])] = name
+	}
+	resolveName := func(nameHash []byte) (string, error) {
+		if name, ok := knownNames[string(nameHash)]; ok {
+			return name, nil
+		}
+		return state.GetState().GetHandshakeNameByHash(nameHash)
 	}
 	for txIndex, tx := range block.Transactions {
+		preflight[txIndex] = make(
+			[]handshakeOutputValidation,
+			len(tx.Outputs),
+		)
 		for outputIndex, output := range tx.Outputs {
 			cov, err := output.Covenant.CheckedCovenant()
 			if err != nil {
-				return fmt.Errorf(
+				return nil, fmt.Errorf(
 					"transaction %d output %d covenant: %w",
 					txIndex,
 					outputIndex,
 					err,
 				)
 			}
+			validation := handshakeOutputValidation{covenant: cov}
 			switch c := cov.(type) {
+			case *handshake.OpenCovenant:
+				rememberName(c.RawName)
+			case *handshake.ClaimCovenant:
+				rememberName(c.RawName)
 			case *handshake.RegisterCovenant:
-				name, err := state.GetState().GetHandshakeNameByHash(c.NameHash)
+				name, err := resolveName(c.NameHash)
 				if err != nil {
-					return fmt.Errorf("resolve register name: %w", err)
+					return nil, fmt.Errorf("resolve register name: %w", err)
 				}
-				if _, err := handshakeResourceDataToDomainRecords(
+				records, err := handshakeResourceDataToDomainRecords(
 					name,
 					c.ResourceData,
-				); err != nil {
-					return fmt.Errorf("validate register records: %w", err)
+				)
+				if err != nil {
+					return nil, fmt.Errorf("validate register records: %w", err)
 				}
+				validation.name = name
+				validation.records = records
 			case *handshake.UpdateCovenant:
-				name, err := state.GetState().GetHandshakeNameByHash(c.NameHash)
+				name, err := resolveName(c.NameHash)
 				if err != nil {
-					return fmt.Errorf("resolve update name: %w", err)
+					return nil, fmt.Errorf("resolve update name: %w", err)
 				}
-				if _, err := handshakeResourceDataToDomainRecords(
+				records, err := handshakeResourceDataToDomainRecords(
 					name,
 					c.ResourceData,
-				); err != nil {
-					return fmt.Errorf("validate update records: %w", err)
+				)
+				if err != nil {
+					return nil, fmt.Errorf("validate update records: %w", err)
 				}
+				validation.name = name
+				validation.records = records
 			case *handshake.RenewCovenant:
-				if _, err := state.GetState().GetHandshakeNameByHash(c.NameHash); err != nil {
-					return fmt.Errorf("resolve renewal name: %w", err)
+				name, err := resolveName(c.NameHash)
+				if err != nil {
+					return nil, fmt.Errorf("resolve renewal name: %w", err)
 				}
+				validation.name = name
 			case *handshake.TransferCovenant:
-				if _, err := state.GetState().GetHandshakeNameByHash(c.NameHash); err != nil {
-					return fmt.Errorf("resolve transfer name: %w", err)
+				name, err := resolveName(c.NameHash)
+				if err != nil {
+					return nil, fmt.Errorf("resolve transfer name: %w", err)
 				}
+				validation.name = name
 			case *handshake.FinalizeCovenant:
 				nameHash := sha3.Sum256([]byte(c.RawName))
 				if !bytes.Equal(c.NameHash, nameHash[:]) {
-					return errors.New("finalize name hash does not match raw name")
+					return nil, errors.New("finalize name hash does not match raw name")
 				}
+				rememberName(c.RawName)
+				validation.name = c.RawName
 			case *handshake.RevokeCovenant:
-				if _, err := state.GetState().GetHandshakeNameByHash(c.NameHash); err != nil {
-					return fmt.Errorf("resolve revoke name: %w", err)
+				name, err := resolveName(c.NameHash)
+				if err != nil {
+					return nil, fmt.Errorf("resolve revoke name: %w", err)
 				}
+				validation.name = name
 			}
+			preflight[txIndex][outputIndex] = validation
 		}
 	}
-	return nil
+	return preflight, nil
 }
 
 func (i *Indexer) startHandshake(stopCh <-chan struct{}) error {
@@ -297,20 +341,19 @@ func (i *Indexer) handshakeHandleSync(block *handshake.Block) error {
 			err,
 		)
 	}
-	// Parse every covenant and resolve every existing-state dependency before
-	// applying any output. This prevents malformed later outputs from causing
-	// avoidable partial state application.
-	if err := validateHandshakeStateChanges(block); err != nil {
+	// Parse every covenant and resolve every state dependency before applying
+	// any output. The preflight also caches these results and tracks names
+	// created earlier in this block without mutating persistent state.
+	preflight, err := validateHandshakeStateChanges(block)
+	if err != nil {
 		return fmt.Errorf("handshake block state preflight failed: %w", err)
 	}
 	// Process transactions
-	for _, tx := range block.Transactions {
+	for txIndex, tx := range block.Transactions {
 		// Process outputs
-		for _, output := range tx.Outputs {
-			cov, err := output.Covenant.CheckedCovenant()
-			if err != nil {
-				return fmt.Errorf("decode Handshake covenant: %w", err)
-			}
+		for outputIndex := range tx.Outputs {
+			validated := preflight[txIndex][outputIndex]
+			cov := validated.covenant
 			switch c := cov.(type) {
 			case *handshake.OpenCovenant:
 				if err := state.GetState().AddHandshakeName(c.RawName); err != nil {
@@ -321,49 +364,25 @@ func (i *Indexer) handshakeHandleSync(block *handshake.Block) error {
 					return err
 				}
 			case *handshake.RegisterCovenant:
-				name, err := state.GetState().GetHandshakeNameByHash(c.NameHash)
-				if err != nil {
-					return err
-				}
+				name := validated.name
 				slog.Debug("Handshake domain registration", "name", name, "resdata", c.ResourceData)
-				records, err := handshakeResourceDataToDomainRecords(name, c.ResourceData)
-				if err != nil {
-					return err
-				}
-				if err := state.GetState().UpdateHandshakeDomain(name, records); err != nil {
+				if err := state.GetState().UpdateHandshakeDomain(name, validated.records); err != nil {
 					return err
 				}
 			case *handshake.UpdateCovenant:
-				name, err := state.GetState().GetHandshakeNameByHash(c.NameHash)
-				if err != nil {
-					return err
-				}
+				name := validated.name
 				slog.Debug("Handshake domain update", "name", name, "resdata", c.ResourceData)
-				records, err := handshakeResourceDataToDomainRecords(name, c.ResourceData)
-				if err != nil {
-					return err
-				}
-				if err := state.GetState().UpdateHandshakeDomain(name, records); err != nil {
+				if err := state.GetState().UpdateHandshakeDomain(name, validated.records); err != nil {
 					return err
 				}
 			case *handshake.RenewCovenant:
-				name, err := state.GetState().GetHandshakeNameByHash(
-					c.NameHash,
-				)
-				if err != nil {
-					return err
-				}
+				name := validated.name
 				slog.Debug(
 					"Handshake domain renewal",
 					"name", name,
 				)
 			case *handshake.TransferCovenant:
-				name, err := state.GetState().GetHandshakeNameByHash(
-					c.NameHash,
-				)
-				if err != nil {
-					return err
-				}
+				name := validated.name
 				slog.Debug(
 					"Handshake domain transfer initiated",
 					"name", name,
@@ -374,23 +393,13 @@ func (i *Indexer) handshakeHandleSync(block *handshake.Block) error {
 				); err != nil {
 					return err
 				}
-				name, err := state.GetState().GetHandshakeNameByHash(
-					c.NameHash,
-				)
-				if err != nil {
-					return err
-				}
+				name := validated.name
 				slog.Debug(
 					"Handshake domain transfer finalized",
 					"name", name,
 				)
 			case *handshake.RevokeCovenant:
-				name, err := state.GetState().GetHandshakeNameByHash(
-					c.NameHash,
-				)
-				if err != nil {
-					return err
-				}
+				name := validated.name
 				slog.Info(
 					"Handshake domain revoked, clearing records",
 					"name", name,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects malformed Handshake input and invalid blocks to prevent deadlocks, bad headers, and partial state writes. The peer no longer depends on Version/Verack order and enforces canonical, in-limit targets; sync re-requests or tears down predictably; and the indexer preflights covenants before writes.

- Protocol: accept Version and Verack in any order, send Verack immediately on Version, reject duplicates, enforce `MsgVersion` payload length and `MsgHeaders` batch limit, and standardize 5s request timeouts.
- Chain and PoW: require a non-empty locator, first header’s parent to match a locator, exact parent linkage, and canonical compact targets within the network PoW limit (prefer `Network.PowLimit`, else `Network.PowLimitBits`; mainnet sets `0x1c00ffff`); `BlockHeader.ValidatePoW` uses checked decoding to reject zero/negative/overflow/non-canonical encodings.
- Sync: when a header batch does not extend the locator, re-request headers (catch-up preserved); when a batch exceeds the network PoW limit, close the peer; fetched blocks must be non-nil, match the requested header, and pass PoW. Tests pin both recovery and teardown paths.
- `internal/indexer`: preflight each output by `CheckedCovenant()`, resolve names (including in-block creations), validate records before writes, verify `Finalize` name hash matches the raw name, and reject nil blocks.

**Migration**
- Callers of `(*GenericCovenant).Covenant()` must handle an error; use `CheckedCovenant()` for untrusted input.

<sup>Written for commit 4d663bd12885962815155c9076138a5a1951779c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cdnsd/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handshake compatibility by accepting Version and Verack messages in either order.
  * Rejects malformed messages, invalid covenant data, excessive header batches, broken header chains, and invalid proof-of-work.
  * Prevents malformed blocks from partially affecting indexer state through pre-processing validation.
  * Verifies synchronized blocks match requested headers and meet proof-of-work requirements.

* **Reliability**
  * Added safer handling for incomplete, unknown, nil, and otherwise malformed blockchain data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->