### PR TITLE
chore: ignore local git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 
 # State directory for local testing
 /.state
+
+# Git worktrees for parallel development
+/.worktrees


### PR DESCRIPTION
## Problem

Git worktrees created inside the repository show up as untracked files in
`git status`, so a broad `git add` can commit them.

## Changes

- Ignore the repository-local `/.worktrees` directory in `.gitignore`.

## Checks

- `git diff --check`
- `golangci-lint v2.13.0 run ./...` — 0 issues
- `govulncheck v1.7.0` under go1.26.7 — 0 vulnerabilities

Ignore-only change; no build or runtime behavior is affected.

## Summary by Cubic

Ignore the repository-local `.worktrees` directory by adding `/.worktrees` to
`.gitignore`. Previously these files appeared in `git status` and could be
committed; now they are ignored with no build or runtime impact.

Review notes:

- Only the top-level `/.worktrees` is ignored; no source changes.
- If `.worktrees` had been tracked, it would also need
  `git rm -r --cached .worktrees`. It is not tracked in this repository, so no
  such cleanup is required.

## Summary by CodeRabbit

Chores: updated project exclusions to prevent Git worktree files from appearing
as untracked changes.
