### PR TITLE
ci: restore cdnsd CI after toolchain drift

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -36,6 +36,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.25.12, 1.26.5]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -36,6 +36,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.26.x
+          go-version: 1.25.x
       - name: govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -36,6 +36,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.x
       - name: govulncheck
-        run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.25.12
+          go-version: 1.25.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.3.0

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.25.12
+          go-version: 1.25.x
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: '0'
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.25.12
+          go-version: 1.25.x
       - name: Build binary
         run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
       - name: Upload release asset

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -816,7 +816,7 @@ func (r *Resolver) handleQuery(w dns.ResponseWriter, req *dns.Msg) {
 			for nameserver, addresses := range nameservers {
 				// NS record
 				ns := &dns.NS{
-					Hdr: dns.RR_Header{Name: (nameserverDomain), Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 999},
+					Hdr: dns.RR_Header{Name: nameserverDomain, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 999},
 					Ns:  nameserver,
 				}
 				m.Ns = append(m.Ns, ns)


### PR DESCRIPTION
Two checks fail on every open cdnsd pull request, including #632, which edits
only `.gitignore`. Neither is caused by any open diff; both are toolchain
drift from exact patch pins going stale.

## 1. govulncheck — pinned Go patch went stale

The job pinned `go-version: 1.26.5`, whose standard library is affected by five
advisories cdnsd's code reaches:

| Advisory | Package | Fixed in |
| --- | --- | --- |
| GO-2026-6218 | `net/url` | go1.26.6 |
| GO-2026-6090 | `crypto/tls` | go1.26.6 |
| GO-2026-6089 | `net/http` | go1.26.6 |
| GO-2026-5972 | `encoding/asn1` | go1.26.6 |
| GO-2026-5026 | `net/http` | go1.26.6 |

The more serious find was next to it: `publish.yml` built **releases** on an
exact `1.25.12` pin, and 1.25.12 carries all five (fixed in go1.25.13). Shipped
binaries were affected, and no check would have said so.

Every `go-version` in `.github/workflows/` is now floating, matching
`repos-config.yaml`:

| Workflow | Was | Now |
| --- | --- | --- |
| `publish.yml` | `1.25.12` | `1.25.x` |
| `go-test.yml` (matrix) | `[1.25.12, 1.26.5]` | `[1.25.x, 1.26.x]` |
| `go-test.yml` (govulncheck) | `1.26.5` | `1.26.x` |
| `nilaway.yml` | `1.25.12` | `1.25.x` |
| `golangci-lint.yml` | `1.25.12` | `1.25.x` |

`govulncheck` also moves from v1.1.4 to v1.7.0.

The scanner stays on the newest supported minor rather than dropping to match
`publish`, so it sees the newest stdlib and the newest advisory data. Floating
`publish` is what keeps the shipped stdlib patched.

## 2. lint — floating golangci-lint version got stricter

`golangci-lint-action` is pinned by SHA but takes no `version:` input, so it
installs the latest release, now v2.13.0. Its bundled gofumpt rejects the
redundant parentheses in `internal/dns/dns.go:819`, a line unchanged on main.
This is the unpinned action working as intended — the finding is real and now
fixed.

## Verification

| Check | Result |
| --- | --- |
| `govulncheck` v1.1.4 under go1.26.5 (old config) | exit 3 — 5 called stdlib vulns |
| `govulncheck` v1.7.0 under go1.25.12 (old `publish` pin) | exit 3 — same 5 advisories |
| `govulncheck` v1.7.0 under go1.26.7 (floated `1.26.x`) | exit 0 — no vulnerabilities |
| `golangci-lint v2.13.0 run ./...` on `origin/main` | `dns.go:819:1 not properly formatted` |
| `golangci-lint v2.13.0 run ./...` on this branch | `0 issues.` |

Unblocks #620, #621, #622, and #632.

The `lint` failure is not specific to cdnsd; `golangci-lint-action` is unpinned
org-wide and v2.13.0's gofumpt affects most Blink Labs Go repositories. Tracked
in blinklabs-io/actions#103.
